### PR TITLE
feat!: OpenSeadragon 6 data pipeline with raw zarr chunk access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `dataType` option (`"context2d"` or `"zarrChunk"`) to configure the data type produced by the tile source
+- `zarrChunk` OpenSeadragon data type for accessing the raw zarr data of a tile, with a `zarrChunk` → `context2d` converter
+
 ### Changed
 
+- Tiles are produced as `context2d` (OpenSeadragon 6 data pipeline) instead of `image` (PNG data URL)
+- Updated ome-zarr.js to 0.0.20 (`renderArray` API) and zarrita to 0.7.5
+- Missing channel window `start`/`end` values are derived once from the smallest resolution level instead of per tile
+- The `c` option now restricts rendering to the selected channel
+- Requires OpenSeadragon 6 or newer
+- Import `ZipFileStore` from `@zarrita/storage/zip` so that Node-only stores are no longer bundled
+
 ### Removed
+
+- Support for OpenSeadragon 5
+- `vite-plugin-node-polyfills` build dependency (no longer needed)
 
 ## [0.2.0] - 2026-05-25
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ An OpenSeadragon tile source for the OME-Zarr bioimage file format
 
 ## Prerequisites
 
-OpenSeadragon 5 or newer
+OpenSeadragon 6 or newer
 
 ## Installation
 
@@ -66,6 +66,44 @@ const viewer = OpenSeadragon(
     ]
 );
 ```
+
+### Options
+
+| Option     | Default       | Description                                                                                                  |
+| ---------- | ------------- | ------------------------------------------------------------------------------------------------------------ |
+| `url`      | required      | URL of the OME-Zarr image (group containing the `multiscales` metadata)                                      |
+| `zip`      | `undefined`   | Read a zipped OME-Zarr (`.ozx`) via HTTP range requests; `undefined` auto-detects based on the `.ozx` suffix |
+| `t`, `z`   | `undefined`   | Time point / z-slice to show; defaults to the omero `rdefs` defaults (the middle plane if not available)     |
+| `c`        | `undefined`   | Render only this channel; by default all channels marked as active in the omero metadata are rendered        |
+| `dataType` | `"context2d"` | Data type produced per tile, see below                                                                       |
+
+### Data types
+
+OMEZarrTileSource is built on the [OpenSeadragon 6 data pipeline](https://openseadragon.github.io/examples/data-types/) and can produce tiles as one of two data types:
+
+- `"context2d"` (default): tiles are rendered by [ome-zarr.js](https://github.com/BioNGFF/ome-zarr.js) according to the omero metadata (channel colors, windows, LUTs) and delivered as `CanvasRenderingContext2D` objects, which OpenSeadragon draws directly. Only the active channels are fetched.
+- `"zarrChunk"`: tiles are delivered as raw [zarrita](https://zarrita.dev) chunks (`{ data, shape, stride }`), covering the tile region in x/y, the selected `t`/`z`/`c` plane (length 1) and, if `c` is not set, _all_ channels. The chunk has the same rank as the underlying array, i.e. `chunk.shape` aligns with the `axes` of the OME-Zarr `multiscales` metadata. OpenSeadragon renders such tiles through the `zarrChunk` → `context2d` converter registered by OMEZarrTileSource, so the image still shows up without further work.
+
+Access the data in a [`tile-invalidated`](https://openseadragon.github.io/examples/data-modifications/) handler:
+
+```javascript
+const viewer = OpenSeadragon({
+    ...
+    tileSources: { type: "ome-zarr", url: url, dataType: "zarrChunk" },
+});
+
+viewer.addHandler("tile-invalidated", async (event) => {
+    const chunk = await event.getData("zarrChunk"); // raw pixel values
+    const ctx = await event.getData("context2d"); // rendered tile
+    // e.g. custom rendering:
+    // await event.setData(myCanvas.getContext("2d"), "context2d");
+});
+```
+
+Notes:
+
+- OpenSeadragon keeps a single data type per cache record. The raw chunk is always available to `tile-invalidated` handlers when a tile is loaded; it is kept afterwards (e.g. for `viewer.requestInvalidate()`) only if a handler accessed or modified the data, otherwise OpenSeadragon converts it in place to the drawer's type.
+- If a channel window has no `start`/`end`, they are derived once from the smallest resolution level when the image is opened, so all tiles share the same range.
 
 ## Example
 

--- a/index.html
+++ b/index.html
@@ -8,7 +8,16 @@
 
   <body>
     <h1>OMEZarrTileSource</h1>
+    <h2>Rendered by the tile source (<code>dataType: "context2d"</code>)</h2>
     <div id="viewer" style="width: 1280px; height: 1024px"></div>
+    <h2>Raw data (<code>dataType: "zarrChunk"</code>)</h2>
+    <p>
+      Tiles are delivered as zarrita chunks; OpenSeadragon renders them via the
+      registered <code>zarrChunk &rarr; context2d</code> converter. Open the
+      console to see the chunk shapes logged by the
+      <code>tile-invalidated</code> handler.
+    </p>
+    <div id="raw-viewer" style="width: 1280px; height: 1024px"></div>
     <script type="module">
       import OpenSeadragon from "openseadragon";
 
@@ -17,17 +26,42 @@
 
       OMEZarrTileSource.enable(OpenSeadragon);
 
+      const url =
+        "https://livingobjects.ebi.ac.uk/idr/zarr/v0.5/idr0062A/6001240_labels.zarr";
+
       new OpenSeadragon.Viewer({
         id: "viewer",
         tileSources: {
           type: "ome-zarr",
-          url: "https://livingobjects.ebi.ac.uk/idr/zarr/v0.5/idr0062A/6001240_labels.zarr",
+          url: url,
           z: 128,
         },
         prefixUrl: "https://openseadragon.github.io/openseadragon/images/",
         timeout: 60000, // increase timeout for large images,
         minZoomImageRatio: 0, // allow zooming out indefinitely
         maxZoomPixelRatio: Infinity, // allow zooming in indefinitely
+      });
+
+      const rawViewer = new OpenSeadragon.Viewer({
+        id: "raw-viewer",
+        tileSources: {
+          type: "ome-zarr",
+          url: url,
+          z: 128,
+          dataType: "zarrChunk",
+        },
+        prefixUrl: "https://openseadragon.github.io/openseadragon/images/",
+        timeout: 60000,
+        minZoomImageRatio: 0,
+        maxZoomPixelRatio: Infinity,
+      });
+
+      rawViewer.addHandler("tile-invalidated", async (event) => {
+        // zarrita chunk with the same rank as the array (axes as in the multiscales metadata)
+        const chunk = await event.getData("zarrChunk");
+        console.log(
+          `tile ${event.tile.toString()}: shape=[${chunk.shape}] dtype=${chunk.data.constructor.name}`,
+        );
       });
     </script>
   </body>

--- a/package.json
+++ b/package.json
@@ -39,11 +39,11 @@
   },
   "dependencies": {
     "@zarrita/storage": "0.2.0",
-    "ome-zarr.js": "0.0.19",
-    "zarrita": "0.5.4"
+    "ome-zarr.js": "0.0.20",
+    "zarrita": "0.7.5"
   },
   "peerDependencies": {
-    "openseadragon": ">=5.0.1 <7.0.0"
+    "openseadragon": ">=6.0.0 <7.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
@@ -54,13 +54,12 @@
     "eslint-config-prettier": "^10.1.8",
     "husky": "^9.1.7",
     "lint-staged": "^17.0.5",
-    "openseadragon": ">=5.0.1 <7.0.0",
+    "openseadragon": ">=6.0.0 <7.0.0",
     "prettier": "^3.8.3",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.4",
     "unplugin-dts": "1.0.1",
     "vite": "^8.0.14",
-    "vite-plugin-node-polyfills": "^0.28.0",
     "vitest": "^4.1.7"
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,11 +11,11 @@ importers:
         specifier: 0.2.0
         version: 0.2.0
       ome-zarr.js:
-        specifier: 0.0.19
-        version: 0.0.19
+        specifier: 0.0.20
+        version: 0.0.20
       zarrita:
-        specifier: 0.5.4
-        version: 0.5.4
+        specifier: 0.7.5
+        version: 0.7.5
     devDependencies:
       "@eslint/js":
         specifier: ^10.0.1
@@ -42,7 +42,7 @@ importers:
         specifier: ^17.0.5
         version: 17.0.5
       openseadragon:
-        specifier: ">=5.0.1 <7.0.0"
+        specifier: ">=6.0.0 <7.0.0"
         version: 6.0.2
       prettier:
         specifier: ^3.8.3
@@ -59,9 +59,6 @@ importers:
       vite:
         specifier: ^8.0.14
         version: 8.0.14(yaml@2.9.0)
-      vite-plugin-node-polyfills:
-        specifier: ^0.28.0
-        version: 0.28.0(vite@8.0.14(yaml@2.9.0))
       vitest:
         specifier: ^4.1.7
         version: 4.1.7(@vitest/coverage-v8@4.1.7)(vite@8.0.14(yaml@2.9.0))
@@ -471,18 +468,6 @@ packages:
         integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==,
       }
 
-  "@rollup/plugin-inject@5.0.5":
-    resolution:
-      {
-        integrity: sha512-2+DEJbNBoPROPkgTDNe8/1YXWcqxbN5DTjASVIOx8HS+pITXushyNiBV56RB08zuptzz8gT3YfkqriTBVycepg==,
-      }
-    engines: { node: ">=14.0.0" }
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-
   "@rollup/pluginutils@5.3.0":
     resolution:
       {
@@ -779,12 +764,6 @@ packages:
         integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==,
       }
 
-  "@zarrita/storage@0.1.4":
-    resolution:
-      {
-        integrity: sha512-qURfJAQcQGRfDQ4J9HaCjGaj3jlJKc66bnRk6G/IeLUsM7WKyG7Bzsuf1EZurSXyc0I4LVcu6HaeQQ4d3kZ16g==,
-      }
-
   "@zarrita/storage@0.2.0":
     resolution:
       {
@@ -868,18 +847,6 @@ packages:
         integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==,
       }
 
-  asn1.js@4.10.1:
-    resolution:
-      {
-        integrity: sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==,
-      }
-
-  assert@2.1.0:
-    resolution:
-      {
-        integrity: sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==,
-      }
-
   assertion-error@2.0.1:
     resolution:
       {
@@ -892,13 +859,6 @@ packages:
       {
         integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==,
       }
-
-  available-typed-arrays@1.0.7:
-    resolution:
-      {
-        integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==,
-      }
-    engines: { node: ">= 0.4" }
 
   balanced-match@1.0.2:
     resolution:
@@ -913,24 +873,6 @@ packages:
       }
     engines: { node: 18 || 20 || >=22 }
 
-  base64-js@1.5.1:
-    resolution:
-      {
-        integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==,
-      }
-
-  bn.js@4.12.3:
-    resolution:
-      {
-        integrity: sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==,
-      }
-
-  bn.js@5.2.3:
-    resolution:
-      {
-        integrity: sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==,
-      }
-
   brace-expansion@2.1.0:
     resolution:
       {
@@ -944,108 +886,12 @@ packages:
       }
     engines: { node: 18 || 20 || >=22 }
 
-  brorand@1.1.0:
-    resolution:
-      {
-        integrity: sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==,
-      }
-
-  browser-resolve@2.0.0:
-    resolution:
-      {
-        integrity: sha512-7sWsQlYL2rGLy2IWm8WL8DCTJvYLc/qlOnsakDac87SOoCd16WLsaAMdCiAqsTNHIe+SXfaqyxyo6THoWqs8WQ==,
-      }
-
-  browserify-aes@1.2.0:
-    resolution:
-      {
-        integrity: sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==,
-      }
-
-  browserify-cipher@1.0.1:
-    resolution:
-      {
-        integrity: sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==,
-      }
-
-  browserify-des@1.0.2:
-    resolution:
-      {
-        integrity: sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==,
-      }
-
-  browserify-rsa@4.1.1:
-    resolution:
-      {
-        integrity: sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==,
-      }
-    engines: { node: ">= 0.10" }
-
-  browserify-sign@4.2.6:
-    resolution:
-      {
-        integrity: sha512-sd+Q65fjlWCYWtZKXiKfrUc8d+4jtp/8f0W2NkwzLtoW4bI6UDnWusLWIurHnmurW0XShIRxpwiOX4EoPtXUAg==,
-      }
-    engines: { node: ">= 0.10" }
-
-  browserify-zlib@0.2.0:
-    resolution:
-      {
-        integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==,
-      }
-
-  buffer-xor@1.0.3:
-    resolution:
-      {
-        integrity: sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==,
-      }
-
-  buffer@5.7.1:
-    resolution:
-      {
-        integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==,
-      }
-
-  builtin-status-codes@3.0.0:
-    resolution:
-      {
-        integrity: sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==,
-      }
-
-  call-bind-apply-helpers@1.0.2:
-    resolution:
-      {
-        integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==,
-      }
-    engines: { node: ">= 0.4" }
-
-  call-bind@1.0.9:
-    resolution:
-      {
-        integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==,
-      }
-    engines: { node: ">= 0.4" }
-
-  call-bound@1.0.4:
-    resolution:
-      {
-        integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==,
-      }
-    engines: { node: ">= 0.4" }
-
   chai@6.2.2:
     resolution:
       {
         integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==,
       }
     engines: { node: ">=18" }
-
-  cipher-base@1.0.7:
-    resolution:
-      {
-        integrity: sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==,
-      }
-    engines: { node: ">= 0.10" }
 
   cli-cursor@5.0.0:
     resolution:
@@ -1079,52 +925,10 @@ packages:
         integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==,
       }
 
-  console-browserify@1.2.0:
-    resolution:
-      {
-        integrity: sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==,
-      }
-
-  constants-browserify@1.0.0:
-    resolution:
-      {
-        integrity: sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==,
-      }
-
   convert-source-map@2.0.0:
     resolution:
       {
         integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==,
-      }
-
-  core-util-is@1.0.3:
-    resolution:
-      {
-        integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==,
-      }
-
-  create-ecdh@4.0.4:
-    resolution:
-      {
-        integrity: sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==,
-      }
-
-  create-hash@1.2.0:
-    resolution:
-      {
-        integrity: sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==,
-      }
-
-  create-hmac@1.1.7:
-    resolution:
-      {
-        integrity: sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==,
-      }
-
-  create-require@1.1.1:
-    resolution:
-      {
-        integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==,
       }
 
   cross-spawn@7.0.6:
@@ -1133,13 +937,6 @@ packages:
         integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==,
       }
     engines: { node: ">= 8" }
-
-  crypto-browserify@3.12.1:
-    resolution:
-      {
-        integrity: sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==,
-      }
-    engines: { node: ">= 0.10" }
 
   debug@4.4.3:
     resolution:
@@ -1159,26 +956,6 @@ packages:
         integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==,
       }
 
-  define-data-property@1.1.4:
-    resolution:
-      {
-        integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==,
-      }
-    engines: { node: ">= 0.4" }
-
-  define-properties@1.2.1:
-    resolution:
-      {
-        integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==,
-      }
-    engines: { node: ">= 0.4" }
-
-  des.js@1.1.0:
-    resolution:
-      {
-        integrity: sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==,
-      }
-
   detect-libc@2.1.2:
     resolution:
       {
@@ -1193,32 +970,6 @@ packages:
       }
     engines: { node: ">=0.3.1" }
 
-  diffie-hellman@5.0.3:
-    resolution:
-      {
-        integrity: sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==,
-      }
-
-  domain-browser@4.22.0:
-    resolution:
-      {
-        integrity: sha512-IGBwjF7tNk3cwypFNH/7bfzBcgSCbaMOD3GsaY1AU/JRrnHnYgEM0+9kQt52iZxjNsjBtJYtao146V+f8jFZNw==,
-      }
-    engines: { node: ">=10" }
-
-  dunder-proto@1.0.1:
-    resolution:
-      {
-        integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==,
-      }
-    engines: { node: ">= 0.4" }
-
-  elliptic@6.6.1:
-    resolution:
-      {
-        integrity: sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==,
-      }
-
   emoji-regex@10.6.0:
     resolution:
       {
@@ -1232,13 +983,6 @@ packages:
       }
     engines: { node: ">=18" }
 
-  es-define-property@1.0.1:
-    resolution:
-      {
-        integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==,
-      }
-    engines: { node: ">= 0.4" }
-
   es-errors@1.3.0:
     resolution:
       {
@@ -1251,13 +995,6 @@ packages:
       {
         integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==,
       }
-
-  es-object-atoms@1.1.2:
-    resolution:
-      {
-        integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==,
-      }
-    engines: { node: ">= 0.4" }
 
   escape-string-regexp@4.0.0:
     resolution:
@@ -1362,19 +1099,6 @@ packages:
         integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==,
       }
 
-  events@3.3.0:
-    resolution:
-      {
-        integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==,
-      }
-    engines: { node: ">=0.8.x" }
-
-  evp_bytestokey@1.0.3:
-    resolution:
-      {
-        integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==,
-      }
-
   expect-type@1.3.0:
     resolution:
       {
@@ -1457,13 +1181,6 @@ packages:
         integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==,
       }
 
-  for-each@0.3.5:
-    resolution:
-      {
-        integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==,
-      }
-    engines: { node: ">= 0.4" }
-
   fs-extra@11.3.5:
     resolution:
       {
@@ -1485,13 +1202,6 @@ packages:
         integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==,
       }
 
-  generator-function@2.0.1:
-    resolution:
-      {
-        integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==,
-      }
-    engines: { node: ">= 0.4" }
-
   get-east-asian-width@1.6.0:
     resolution:
       {
@@ -1499,33 +1209,12 @@ packages:
       }
     engines: { node: ">=18" }
 
-  get-intrinsic@1.3.0:
-    resolution:
-      {
-        integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==,
-      }
-    engines: { node: ">= 0.4" }
-
-  get-proto@1.0.1:
-    resolution:
-      {
-        integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==,
-      }
-    engines: { node: ">= 0.4" }
-
   glob-parent@6.0.2:
     resolution:
       {
         integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==,
       }
     engines: { node: ">=10.13.0" }
-
-  gopd@1.2.0:
-    resolution:
-      {
-        integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==,
-      }
-    engines: { node: ">= 0.4" }
 
   graceful-fs@4.2.11:
     resolution:
@@ -1540,46 +1229,6 @@ packages:
       }
     engines: { node: ">=8" }
 
-  has-property-descriptors@1.0.2:
-    resolution:
-      {
-        integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==,
-      }
-
-  has-symbols@1.1.0:
-    resolution:
-      {
-        integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==,
-      }
-    engines: { node: ">= 0.4" }
-
-  has-tostringtag@1.0.2:
-    resolution:
-      {
-        integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==,
-      }
-    engines: { node: ">= 0.4" }
-
-  hash-base@3.0.5:
-    resolution:
-      {
-        integrity: sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg==,
-      }
-    engines: { node: ">= 0.10" }
-
-  hash-base@3.1.2:
-    resolution:
-      {
-        integrity: sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==,
-      }
-    engines: { node: ">= 0.8" }
-
-  hash.js@1.1.7:
-    resolution:
-      {
-        integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==,
-      }
-
   hasown@2.0.3:
     resolution:
       {
@@ -1587,22 +1236,10 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
-  hmac-drbg@1.0.1:
-    resolution:
-      {
-        integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==,
-      }
-
   html-escaper@2.0.2:
     resolution:
       {
         integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==,
-      }
-
-  https-browserify@1.0.0:
-    resolution:
-      {
-        integrity: sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==,
       }
 
   husky@9.1.7:
@@ -1612,12 +1249,6 @@ packages:
       }
     engines: { node: ">=18" }
     hasBin: true
-
-  ieee754@1.2.1:
-    resolution:
-      {
-        integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==,
-      }
 
   ignore@5.3.2:
     resolution:
@@ -1647,26 +1278,6 @@ packages:
       }
     engines: { node: ">=0.8.19" }
 
-  inherits@2.0.4:
-    resolution:
-      {
-        integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==,
-      }
-
-  is-arguments@1.2.0:
-    resolution:
-      {
-        integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==,
-      }
-    engines: { node: ">= 0.4" }
-
-  is-callable@1.2.7:
-    resolution:
-      {
-        integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==,
-      }
-    engines: { node: ">= 0.4" }
-
   is-core-module@2.16.2:
     resolution:
       {
@@ -1688,13 +1299,6 @@ packages:
       }
     engines: { node: ">=18" }
 
-  is-generator-function@1.1.2:
-    resolution:
-      {
-        integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==,
-      }
-    engines: { node: ">= 0.4" }
-
   is-glob@4.0.3:
     resolution:
       {
@@ -1702,51 +1306,11 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
-  is-nan@1.3.2:
-    resolution:
-      {
-        integrity: sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==,
-      }
-    engines: { node: ">= 0.4" }
-
-  is-regex@1.2.1:
-    resolution:
-      {
-        integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==,
-      }
-    engines: { node: ">= 0.4" }
-
-  is-typed-array@1.1.15:
-    resolution:
-      {
-        integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==,
-      }
-    engines: { node: ">= 0.4" }
-
-  isarray@1.0.0:
-    resolution:
-      {
-        integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==,
-      }
-
-  isarray@2.0.5:
-    resolution:
-      {
-        integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==,
-      }
-
   isexe@2.0.0:
     resolution:
       {
         integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==,
       }
-
-  isomorphic-timers-promises@1.0.1:
-    resolution:
-      {
-        integrity: sha512-u4sej9B1LPSxTGKB/HiuzvEQnXH0ECYkSVQU39koSwmFAxhlEAFl9RdTvLv4TOTQUgBS5O3O5fwUxk6byBZ+IQ==,
-      }
-    engines: { node: ">=10" }
 
   istanbul-lib-coverage@3.2.2:
     resolution:
@@ -2021,44 +1585,12 @@ packages:
       }
     engines: { node: ">=10" }
 
-  math-intrinsics@1.1.0:
-    resolution:
-      {
-        integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==,
-      }
-    engines: { node: ">= 0.4" }
-
-  md5.js@1.3.5:
-    resolution:
-      {
-        integrity: sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==,
-      }
-
-  miller-rabin@4.0.1:
-    resolution:
-      {
-        integrity: sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==,
-      }
-    hasBin: true
-
   mimic-function@5.0.1:
     resolution:
       {
         integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==,
       }
     engines: { node: ">=18" }
-
-  minimalistic-assert@1.0.1:
-    resolution:
-      {
-        integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==,
-      }
-
-  minimalistic-crypto-utils@1.0.1:
-    resolution:
-      {
-        integrity: sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==,
-      }
 
   minimatch@10.2.3:
     resolution:
@@ -2107,46 +1639,11 @@ packages:
         integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==,
       }
 
-  node-stdlib-browser@1.3.1:
-    resolution:
-      {
-        integrity: sha512-X75ZN8DCLftGM5iKwoYLA3rjnrAEs97MkzvSd4q2746Tgpg8b8XWiBGiBG4ZpgcAqBgtgPHTiAc8ZMCvZuikDw==,
-      }
-    engines: { node: ">=10" }
-
   numcodecs@0.3.2:
     resolution:
       {
         integrity: sha512-6YSPnmZgg0P87jnNhi3s+FVLOcIn3y+1CTIgUulA3IdASzK9fJM87sUFkpyA+be9GibGRaST2wCgkD+6U+fWKw==,
       }
-
-  object-inspect@1.13.4:
-    resolution:
-      {
-        integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==,
-      }
-    engines: { node: ">= 0.4" }
-
-  object-is@1.1.6:
-    resolution:
-      {
-        integrity: sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==,
-      }
-    engines: { node: ">= 0.4" }
-
-  object-keys@1.1.1:
-    resolution:
-      {
-        integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==,
-      }
-    engines: { node: ">= 0.4" }
-
-  object.assign@4.1.7:
-    resolution:
-      {
-        integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==,
-      }
-    engines: { node: ">= 0.4" }
 
   obug@2.1.1:
     resolution:
@@ -2154,10 +1651,10 @@ packages:
         integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==,
       }
 
-  ome-zarr.js@0.0.19:
+  ome-zarr.js@0.0.20:
     resolution:
       {
-        integrity: sha512-z+pP9AlUMvkfHBQ24F9KsjRgIDq9taeC23///ZQA/gzWOjlgbkcJlraJhjljESQC9fYYs+FiWkPsp7TAcS77ag==,
+        integrity: sha512-CvKZykEKILCXjtBYFwTiddw6eS2l2T1CA3nHH1QLure/HbBBD6e2uN/nJSMNP9m661EWWHNPKr8ggaDBxLDvzw==,
       }
 
   onetime@7.0.0:
@@ -2180,12 +1677,6 @@ packages:
       }
     engines: { node: ">= 0.8.0" }
 
-  os-browserify@0.3.0:
-    resolution:
-      {
-        integrity: sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==,
-      }
-
   p-limit@3.1.0:
     resolution:
       {
@@ -2199,19 +1690,6 @@ packages:
         integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==,
       }
     engines: { node: ">=10" }
-
-  pako@1.0.11:
-    resolution:
-      {
-        integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==,
-      }
-
-  parse-asn1@5.1.9:
-    resolution:
-      {
-        integrity: sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg==,
-      }
-    engines: { node: ">= 0.10" }
 
   parse-imports-exports@0.2.4:
     resolution:
@@ -2257,13 +1735,6 @@ packages:
         integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==,
       }
 
-  pbkdf2@3.1.5:
-    resolution:
-      {
-        integrity: sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==,
-      }
-    engines: { node: ">= 0.10" }
-
   picocolors@1.1.1:
     resolution:
       {
@@ -2277,13 +1748,6 @@ packages:
       }
     engines: { node: ">=12" }
 
-  pkg-dir@5.0.0:
-    resolution:
-      {
-        integrity: sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==,
-      }
-    engines: { node: ">=10" }
-
   pkg-types@1.3.1:
     resolution:
       {
@@ -2295,13 +1759,6 @@ packages:
       {
         integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==,
       }
-
-  possible-typed-array-names@1.1.0:
-    resolution:
-      {
-        integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==,
-      }
-    engines: { node: ">= 0.4" }
 
   postcss@8.5.15:
     resolution:
@@ -2325,31 +1782,6 @@ packages:
     engines: { node: ">=14" }
     hasBin: true
 
-  process-nextick-args@2.0.1:
-    resolution:
-      {
-        integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==,
-      }
-
-  process@0.11.10:
-    resolution:
-      {
-        integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==,
-      }
-    engines: { node: ">= 0.6.0" }
-
-  public-encrypt@4.0.3:
-    resolution:
-      {
-        integrity: sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==,
-      }
-
-  punycode@1.4.1:
-    resolution:
-      {
-        integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==,
-      }
-
   punycode@2.3.1:
     resolution:
       {
@@ -2357,50 +1789,11 @@ packages:
       }
     engines: { node: ">=6" }
 
-  qs@6.15.2:
-    resolution:
-      {
-        integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==,
-      }
-    engines: { node: ">=0.6" }
-
   quansync@0.2.11:
     resolution:
       {
         integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==,
       }
-
-  querystring-es3@0.2.1:
-    resolution:
-      {
-        integrity: sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==,
-      }
-    engines: { node: ">=0.4.x" }
-
-  randombytes@2.1.0:
-    resolution:
-      {
-        integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==,
-      }
-
-  randomfill@1.0.4:
-    resolution:
-      {
-        integrity: sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==,
-      }
-
-  readable-stream@2.3.8:
-    resolution:
-      {
-        integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==,
-      }
-
-  readable-stream@3.6.2:
-    resolution:
-      {
-        integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==,
-      }
-    engines: { node: ">= 6" }
 
   reference-spec-reader@0.2.0:
     resolution:
@@ -2436,13 +1829,6 @@ packages:
         integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==,
       }
 
-  ripemd160@2.0.3:
-    resolution:
-      {
-        integrity: sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==,
-      }
-    engines: { node: ">= 0.8" }
-
   rolldown@1.0.2:
     resolution:
       {
@@ -2450,25 +1836,6 @@ packages:
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     hasBin: true
-
-  safe-buffer@5.1.2:
-    resolution:
-      {
-        integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==,
-      }
-
-  safe-buffer@5.2.1:
-    resolution:
-      {
-        integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==,
-      }
-
-  safe-regex-test@1.1.0:
-    resolution:
-      {
-        integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==,
-      }
-    engines: { node: ">= 0.4" }
 
   semver@7.7.4:
     resolution:
@@ -2486,27 +1853,6 @@ packages:
     engines: { node: ">=10" }
     hasBin: true
 
-  set-function-length@1.2.2:
-    resolution:
-      {
-        integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==,
-      }
-    engines: { node: ">= 0.4" }
-
-  setimmediate@1.0.5:
-    resolution:
-      {
-        integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==,
-      }
-
-  sha.js@2.4.12:
-    resolution:
-      {
-        integrity: sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==,
-      }
-    engines: { node: ">= 0.10" }
-    hasBin: true
-
   shebang-command@2.0.0:
     resolution:
       {
@@ -2520,34 +1866,6 @@ packages:
         integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==,
       }
     engines: { node: ">=8" }
-
-  side-channel-list@1.0.1:
-    resolution:
-      {
-        integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==,
-      }
-    engines: { node: ">= 0.4" }
-
-  side-channel-map@1.0.1:
-    resolution:
-      {
-        integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==,
-      }
-    engines: { node: ">= 0.4" }
-
-  side-channel-weakmap@1.0.2:
-    resolution:
-      {
-        integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==,
-      }
-    engines: { node: ">= 0.4" }
-
-  side-channel@1.1.0:
-    resolution:
-      {
-        integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==,
-      }
-    engines: { node: ">= 0.4" }
 
   siginfo@2.0.0:
     resolution:
@@ -2608,18 +1926,6 @@ packages:
         integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==,
       }
 
-  stream-browserify@3.0.0:
-    resolution:
-      {
-        integrity: sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==,
-      }
-
-  stream-http@3.2.0:
-    resolution:
-      {
-        integrity: sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A==,
-      }
-
   string-argv@0.3.2:
     resolution:
       {
@@ -2640,18 +1946,6 @@ packages:
         integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==,
       }
     engines: { node: ">=20" }
-
-  string_decoder@1.1.1:
-    resolution:
-      {
-        integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==,
-      }
-
-  string_decoder@1.3.0:
-    resolution:
-      {
-        integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==,
-      }
 
   strip-ansi@7.2.0:
     resolution:
@@ -2681,13 +1975,6 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
-  timers-browserify@2.0.12:
-    resolution:
-      {
-        integrity: sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==,
-      }
-    engines: { node: ">=0.6.0" }
-
   tinybench@2.9.0:
     resolution:
       {
@@ -2715,13 +2002,6 @@ packages:
       }
     engines: { node: ">=14.0.0" }
 
-  to-buffer@1.2.2:
-    resolution:
-      {
-        integrity: sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==,
-      }
-    engines: { node: ">= 0.4" }
-
   ts-api-utils@2.5.0:
     resolution:
       {
@@ -2737,25 +2017,12 @@ packages:
         integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==,
       }
 
-  tty-browserify@0.0.1:
-    resolution:
-      {
-        integrity: sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==,
-      }
-
   type-check@0.4.0:
     resolution:
       {
         integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==,
       }
     engines: { node: ">= 0.8.0" }
-
-  typed-array-buffer@1.0.3:
-    resolution:
-      {
-        integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==,
-      }
-    engines: { node: ">= 0.4" }
 
   typescript-eslint@8.59.4:
     resolution:
@@ -2836,13 +2103,6 @@ packages:
       }
     engines: { node: ">=18.12.0" }
 
-  unzipit@1.4.3:
-    resolution:
-      {
-        integrity: sha512-gsq2PdJIWWGhx5kcdWStvNWit9FVdTewm4SEG7gFskWs+XCVaULt9+BwuoBtJiRE8eo3L1IPAOrbByNLtLtIlg==,
-      }
-    engines: { node: ">=12" }
-
   unzipit@2.0.0:
     resolution:
       {
@@ -2855,39 +2115,6 @@ packages:
       {
         integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==,
       }
-
-  url@0.11.4:
-    resolution:
-      {
-        integrity: sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==,
-      }
-    engines: { node: ">= 0.4" }
-
-  util-deprecate@1.0.2:
-    resolution:
-      {
-        integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==,
-      }
-
-  util@0.12.5:
-    resolution:
-      {
-        integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==,
-      }
-
-  uzip-module@1.0.3:
-    resolution:
-      {
-        integrity: sha512-AMqwWZaknLM77G+VPYNZLEruMGWGzyigPK3/Whg99B3S6vGHuqsyl5ZrOv1UUF3paGK1U6PM0cnayioaryg/fA==,
-      }
-
-  vite-plugin-node-polyfills@0.28.0:
-    resolution:
-      {
-        integrity: sha512-NXct/ci2ef4fRyCfTb8fk2HmR80Rv7icLd+cRH41TnUugDzdKMFKqFPpZYCFUInZMMem9bkLv5pkq02+7Xu7+w==,
-      }
-    peerDependencies:
-      vite: ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
   vite@8.0.14:
     resolution:
@@ -2979,12 +2206,6 @@ packages:
       jsdom:
         optional: true
 
-  vm-browserify@1.1.2:
-    resolution:
-      {
-        integrity: sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==,
-      }
-
   vscode-uri@3.1.0:
     resolution:
       {
@@ -2996,13 +2217,6 @@ packages:
       {
         integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==,
       }
-
-  which-typed-array@1.1.20:
-    resolution:
-      {
-        integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==,
-      }
-    engines: { node: ">= 0.4" }
 
   which@2.0.2:
     resolution:
@@ -3041,13 +2255,6 @@ packages:
       }
     engines: { node: ">=18" }
 
-  xtend@4.0.2:
-    resolution:
-      {
-        integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==,
-      }
-    engines: { node: ">=0.4" }
-
   yaml@2.9.0:
     resolution:
       {
@@ -3063,10 +2270,10 @@ packages:
       }
     engines: { node: ">=10" }
 
-  zarrita@0.5.4:
+  zarrita@0.7.5:
     resolution:
       {
-        integrity: sha512-i88iN2+HqIQ+uiCEWLfhjbYNXAJD7IrM4h3lFwFclfqEOOhxp10amRWtqmgN5jbuy3+h0LwdyLVVzk4y9rTLgg==,
+        integrity: sha512-ZriOSEne+Wf2iuM0yjDZvUKpHNlug3dO7qJ6mAxXoOgsYV18DPOkAkwB9e0rf21bHcKcOffFuwoZwn5g6pvUeA==,
       }
 
 snapshots:
@@ -3298,12 +2505,6 @@ snapshots:
     optional: true
 
   "@rolldown/pluginutils@1.0.1": {}
-
-  "@rollup/plugin-inject@5.0.5":
-    dependencies:
-      "@rollup/pluginutils": 5.3.0
-      estree-walker: 2.0.2
-      magic-string: 0.30.21
 
   "@rollup/pluginutils@5.3.0":
     dependencies:
@@ -3538,11 +2739,6 @@ snapshots:
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
 
-  "@zarrita/storage@0.1.4":
-    dependencies:
-      reference-spec-reader: 0.2.0
-      unzipit: 1.4.3
-
   "@zarrita/storage@0.2.0":
     dependencies:
       reference-spec-reader: 0.2.0
@@ -3588,20 +2784,6 @@ snapshots:
     dependencies:
       sprintf-js: 1.0.3
 
-  asn1.js@4.10.1:
-    dependencies:
-      bn.js: 4.12.3
-      inherits: 2.0.4
-      minimalistic-assert: 1.0.1
-
-  assert@2.1.0:
-    dependencies:
-      call-bind: 1.0.9
-      is-nan: 1.3.2
-      object-is: 1.1.6
-      object.assign: 4.1.7
-      util: 0.12.5
-
   assertion-error@2.0.1: {}
 
   ast-v8-to-istanbul@1.0.0:
@@ -3610,19 +2792,9 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
-  available-typed-arrays@1.0.7:
-    dependencies:
-      possible-typed-array-names: 1.1.0
-
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
-
-  base64-js@1.5.1: {}
-
-  bn.js@4.12.3: {}
-
-  bn.js@5.2.3: {}
 
   brace-expansion@2.1.0:
     dependencies:
@@ -3632,89 +2804,7 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
-  brorand@1.1.0: {}
-
-  browser-resolve@2.0.0:
-    dependencies:
-      resolve: 1.22.12
-
-  browserify-aes@1.2.0:
-    dependencies:
-      buffer-xor: 1.0.3
-      cipher-base: 1.0.7
-      create-hash: 1.2.0
-      evp_bytestokey: 1.0.3
-      inherits: 2.0.4
-      safe-buffer: 5.2.1
-
-  browserify-cipher@1.0.1:
-    dependencies:
-      browserify-aes: 1.2.0
-      browserify-des: 1.0.2
-      evp_bytestokey: 1.0.3
-
-  browserify-des@1.0.2:
-    dependencies:
-      cipher-base: 1.0.7
-      des.js: 1.1.0
-      inherits: 2.0.4
-      safe-buffer: 5.2.1
-
-  browserify-rsa@4.1.1:
-    dependencies:
-      bn.js: 5.2.3
-      randombytes: 2.1.0
-      safe-buffer: 5.2.1
-
-  browserify-sign@4.2.6:
-    dependencies:
-      bn.js: 5.2.3
-      browserify-rsa: 4.1.1
-      create-hash: 1.2.0
-      create-hmac: 1.1.7
-      elliptic: 6.6.1
-      inherits: 2.0.4
-      parse-asn1: 5.1.9
-      readable-stream: 2.3.8
-      safe-buffer: 5.2.1
-
-  browserify-zlib@0.2.0:
-    dependencies:
-      pako: 1.0.11
-
-  buffer-xor@1.0.3: {}
-
-  buffer@5.7.1:
-    dependencies:
-      base64-js: 1.5.1
-      ieee754: 1.2.1
-
-  builtin-status-codes@3.0.0: {}
-
-  call-bind-apply-helpers@1.0.2:
-    dependencies:
-      es-errors: 1.3.0
-      function-bind: 1.1.2
-
-  call-bind@1.0.9:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      es-define-property: 1.0.1
-      get-intrinsic: 1.3.0
-      set-function-length: 1.2.2
-
-  call-bound@1.0.4:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      get-intrinsic: 1.3.0
-
   chai@6.2.2: {}
-
-  cipher-base@1.0.7:
-    dependencies:
-      inherits: 2.0.4
-      safe-buffer: 5.2.1
-      to-buffer: 1.2.2
 
   cli-cursor@5.0.0:
     dependencies:
@@ -3731,37 +2821,7 @@ snapshots:
 
   confbox@0.2.4: {}
 
-  console-browserify@1.2.0: {}
-
-  constants-browserify@1.0.0: {}
-
   convert-source-map@2.0.0: {}
-
-  core-util-is@1.0.3: {}
-
-  create-ecdh@4.0.4:
-    dependencies:
-      bn.js: 4.12.3
-      elliptic: 6.6.1
-
-  create-hash@1.2.0:
-    dependencies:
-      cipher-base: 1.0.7
-      inherits: 2.0.4
-      md5.js: 1.3.5
-      ripemd160: 2.0.3
-      sha.js: 2.4.12
-
-  create-hmac@1.1.7:
-    dependencies:
-      cipher-base: 1.0.7
-      create-hash: 1.2.0
-      inherits: 2.0.4
-      ripemd160: 2.0.3
-      safe-buffer: 5.2.1
-      sha.js: 2.4.12
-
-  create-require@1.1.1: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -3769,85 +2829,23 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  crypto-browserify@3.12.1:
-    dependencies:
-      browserify-cipher: 1.0.1
-      browserify-sign: 4.2.6
-      create-ecdh: 4.0.4
-      create-hash: 1.2.0
-      create-hmac: 1.1.7
-      diffie-hellman: 5.0.3
-      hash-base: 3.0.5
-      inherits: 2.0.4
-      pbkdf2: 3.1.5
-      public-encrypt: 4.0.3
-      randombytes: 2.1.0
-      randomfill: 1.0.4
-
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
   deep-is@0.1.4: {}
 
-  define-data-property@1.1.4:
-    dependencies:
-      es-define-property: 1.0.1
-      es-errors: 1.3.0
-      gopd: 1.2.0
-
-  define-properties@1.2.1:
-    dependencies:
-      define-data-property: 1.1.4
-      has-property-descriptors: 1.0.2
-      object-keys: 1.1.1
-
-  des.js@1.1.0:
-    dependencies:
-      inherits: 2.0.4
-      minimalistic-assert: 1.0.1
-
   detect-libc@2.1.2: {}
 
   diff@8.0.4: {}
-
-  diffie-hellman@5.0.3:
-    dependencies:
-      bn.js: 4.12.3
-      miller-rabin: 4.0.1
-      randombytes: 2.1.0
-
-  domain-browser@4.22.0: {}
-
-  dunder-proto@1.0.1:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      es-errors: 1.3.0
-      gopd: 1.2.0
-
-  elliptic@6.6.1:
-    dependencies:
-      bn.js: 4.12.3
-      brorand: 1.1.0
-      hash.js: 1.1.7
-      hmac-drbg: 1.0.1
-      inherits: 2.0.4
-      minimalistic-assert: 1.0.1
-      minimalistic-crypto-utils: 1.0.1
 
   emoji-regex@10.6.0: {}
 
   environment@1.1.0: {}
 
-  es-define-property@1.0.1: {}
-
   es-errors@1.3.0: {}
 
   es-module-lexer@2.1.0: {}
-
-  es-object-atoms@1.1.2:
-    dependencies:
-      es-errors: 1.3.0
 
   escape-string-regexp@4.0.0: {}
 
@@ -3927,13 +2925,6 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
-  events@3.3.0: {}
-
-  evp_bytestokey@1.0.3:
-    dependencies:
-      md5.js: 1.3.5
-      safe-buffer: 5.2.1
-
   expect-type@1.3.0: {}
 
   exsolve@1.0.8: {}
@@ -3968,10 +2959,6 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  for-each@0.3.5:
-    dependencies:
-      is-callable: 1.2.7
-
   fs-extra@11.3.5:
     dependencies:
       graceful-fs: 4.2.11
@@ -3983,82 +2970,23 @@ snapshots:
 
   function-bind@1.1.2: {}
 
-  generator-function@2.0.1: {}
-
   get-east-asian-width@1.6.0: {}
-
-  get-intrinsic@1.3.0:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      es-define-property: 1.0.1
-      es-errors: 1.3.0
-      es-object-atoms: 1.1.2
-      function-bind: 1.1.2
-      get-proto: 1.0.1
-      gopd: 1.2.0
-      has-symbols: 1.1.0
-      hasown: 2.0.3
-      math-intrinsics: 1.1.0
-
-  get-proto@1.0.1:
-    dependencies:
-      dunder-proto: 1.0.1
-      es-object-atoms: 1.1.2
 
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
 
-  gopd@1.2.0: {}
-
   graceful-fs@4.2.11: {}
 
   has-flag@4.0.0: {}
-
-  has-property-descriptors@1.0.2:
-    dependencies:
-      es-define-property: 1.0.1
-
-  has-symbols@1.1.0: {}
-
-  has-tostringtag@1.0.2:
-    dependencies:
-      has-symbols: 1.1.0
-
-  hash-base@3.0.5:
-    dependencies:
-      inherits: 2.0.4
-      safe-buffer: 5.2.1
-
-  hash-base@3.1.2:
-    dependencies:
-      inherits: 2.0.4
-      readable-stream: 2.3.8
-      safe-buffer: 5.2.1
-      to-buffer: 1.2.2
-
-  hash.js@1.1.7:
-    dependencies:
-      inherits: 2.0.4
-      minimalistic-assert: 1.0.1
 
   hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
 
-  hmac-drbg@1.0.1:
-    dependencies:
-      hash.js: 1.1.7
-      minimalistic-assert: 1.0.1
-      minimalistic-crypto-utils: 1.0.1
-
   html-escaper@2.0.2: {}
 
-  https-browserify@1.0.0: {}
-
   husky@9.1.7: {}
-
-  ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
 
@@ -4067,15 +2995,6 @@ snapshots:
   import-lazy@4.0.0: {}
 
   imurmurhash@0.1.4: {}
-
-  inherits@2.0.4: {}
-
-  is-arguments@1.2.0:
-    dependencies:
-      call-bound: 1.0.4
-      has-tostringtag: 1.0.2
-
-  is-callable@1.2.7: {}
 
   is-core-module@2.16.2:
     dependencies:
@@ -4087,41 +3006,11 @@ snapshots:
     dependencies:
       get-east-asian-width: 1.6.0
 
-  is-generator-function@1.1.2:
-    dependencies:
-      call-bound: 1.0.4
-      generator-function: 2.0.1
-      get-proto: 1.0.1
-      has-tostringtag: 1.0.2
-      safe-regex-test: 1.1.0
-
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
 
-  is-nan@1.3.2:
-    dependencies:
-      call-bind: 1.0.9
-      define-properties: 1.2.1
-
-  is-regex@1.2.1:
-    dependencies:
-      call-bound: 1.0.4
-      gopd: 1.2.0
-      has-tostringtag: 1.0.2
-      hasown: 2.0.3
-
-  is-typed-array@1.1.15:
-    dependencies:
-      which-typed-array: 1.1.20
-
-  isarray@1.0.0: {}
-
-  isarray@2.0.5: {}
-
   isexe@2.0.0: {}
-
-  isomorphic-timers-promises@1.0.1: {}
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -4271,24 +3160,7 @@ snapshots:
     dependencies:
       semver: 7.8.1
 
-  math-intrinsics@1.1.0: {}
-
-  md5.js@1.3.5:
-    dependencies:
-      hash-base: 3.1.2
-      inherits: 2.0.4
-      safe-buffer: 5.2.1
-
-  miller-rabin@4.0.1:
-    dependencies:
-      bn.js: 4.12.3
-      brorand: 1.1.0
-
   mimic-function@5.0.1: {}
-
-  minimalistic-assert@1.0.1: {}
-
-  minimalistic-crypto-utils@1.0.1: {}
 
   minimatch@10.2.3:
     dependencies:
@@ -4315,63 +3187,15 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  node-stdlib-browser@1.3.1:
-    dependencies:
-      assert: 2.1.0
-      browser-resolve: 2.0.0
-      browserify-zlib: 0.2.0
-      buffer: 5.7.1
-      console-browserify: 1.2.0
-      constants-browserify: 1.0.0
-      create-require: 1.1.1
-      crypto-browserify: 3.12.1
-      domain-browser: 4.22.0
-      events: 3.3.0
-      https-browserify: 1.0.0
-      isomorphic-timers-promises: 1.0.1
-      os-browserify: 0.3.0
-      path-browserify: 1.0.1
-      pkg-dir: 5.0.0
-      process: 0.11.10
-      punycode: 1.4.1
-      querystring-es3: 0.2.1
-      readable-stream: 3.6.2
-      stream-browserify: 3.0.0
-      stream-http: 3.2.0
-      string_decoder: 1.3.0
-      timers-browserify: 2.0.12
-      tty-browserify: 0.0.1
-      url: 0.11.4
-      util: 0.12.5
-      vm-browserify: 1.1.2
-
   numcodecs@0.3.2:
     dependencies:
       fflate: 0.8.3
 
-  object-inspect@1.13.4: {}
-
-  object-is@1.1.6:
-    dependencies:
-      call-bind: 1.0.9
-      define-properties: 1.2.1
-
-  object-keys@1.1.1: {}
-
-  object.assign@4.1.7:
-    dependencies:
-      call-bind: 1.0.9
-      call-bound: 1.0.4
-      define-properties: 1.2.1
-      es-object-atoms: 1.1.2
-      has-symbols: 1.1.0
-      object-keys: 1.1.1
-
   obug@2.1.1: {}
 
-  ome-zarr.js@0.0.19:
+  ome-zarr.js@0.0.20:
     dependencies:
-      zarrita: 0.5.4
+      zarrita: 0.7.5
 
   onetime@7.0.0:
     dependencies:
@@ -4388,8 +3212,6 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
-  os-browserify@0.3.0: {}
-
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
@@ -4397,16 +3219,6 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
-
-  pako@1.0.11: {}
-
-  parse-asn1@5.1.9:
-    dependencies:
-      asn1.js: 4.10.1
-      browserify-aes: 1.2.0
-      evp_bytestokey: 1.0.3
-      pbkdf2: 3.1.5
-      safe-buffer: 5.2.1
 
   parse-imports-exports@0.2.4:
     dependencies:
@@ -4424,22 +3236,9 @@ snapshots:
 
   pathe@2.0.3: {}
 
-  pbkdf2@3.1.5:
-    dependencies:
-      create-hash: 1.2.0
-      create-hmac: 1.1.7
-      ripemd160: 2.0.3
-      safe-buffer: 5.2.1
-      sha.js: 2.4.12
-      to-buffer: 1.2.2
-
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
-
-  pkg-dir@5.0.0:
-    dependencies:
-      find-up: 5.0.0
 
   pkg-types@1.3.1:
     dependencies:
@@ -4453,8 +3252,6 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
 
-  possible-typed-array-names@1.1.0: {}
-
   postcss@8.5.15:
     dependencies:
       nanoid: 3.3.12
@@ -4465,55 +3262,9 @@ snapshots:
 
   prettier@3.8.3: {}
 
-  process-nextick-args@2.0.1: {}
-
-  process@0.11.10: {}
-
-  public-encrypt@4.0.3:
-    dependencies:
-      bn.js: 4.12.3
-      browserify-rsa: 4.1.1
-      create-hash: 1.2.0
-      parse-asn1: 5.1.9
-      randombytes: 2.1.0
-      safe-buffer: 5.2.1
-
-  punycode@1.4.1: {}
-
   punycode@2.3.1: {}
 
-  qs@6.15.2:
-    dependencies:
-      side-channel: 1.1.0
-
   quansync@0.2.11: {}
-
-  querystring-es3@0.2.1: {}
-
-  randombytes@2.1.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
-  randomfill@1.0.4:
-    dependencies:
-      randombytes: 2.1.0
-      safe-buffer: 5.2.1
-
-  readable-stream@2.3.8:
-    dependencies:
-      core-util-is: 1.0.3
-      inherits: 2.0.4
-      isarray: 1.0.0
-      process-nextick-args: 2.0.1
-      safe-buffer: 5.1.2
-      string_decoder: 1.1.1
-      util-deprecate: 1.0.2
-
-  readable-stream@3.6.2:
-    dependencies:
-      inherits: 2.0.4
-      string_decoder: 1.3.0
-      util-deprecate: 1.0.2
 
   reference-spec-reader@0.2.0: {}
 
@@ -4532,11 +3283,6 @@ snapshots:
       signal-exit: 4.1.0
 
   rfdc@1.4.1: {}
-
-  ripemd160@2.0.3:
-    dependencies:
-      hash-base: 3.1.2
-      inherits: 2.0.4
 
   rolldown@1.0.2:
     dependencies:
@@ -4559,70 +3305,15 @@ snapshots:
       "@rolldown/binding-win32-arm64-msvc": 1.0.2
       "@rolldown/binding-win32-x64-msvc": 1.0.2
 
-  safe-buffer@5.1.2: {}
-
-  safe-buffer@5.2.1: {}
-
-  safe-regex-test@1.1.0:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      is-regex: 1.2.1
-
   semver@7.7.4: {}
 
   semver@7.8.1: {}
-
-  set-function-length@1.2.2:
-    dependencies:
-      define-data-property: 1.1.4
-      es-errors: 1.3.0
-      function-bind: 1.1.2
-      get-intrinsic: 1.3.0
-      gopd: 1.2.0
-      has-property-descriptors: 1.0.2
-
-  setimmediate@1.0.5: {}
-
-  sha.js@2.4.12:
-    dependencies:
-      inherits: 2.0.4
-      safe-buffer: 5.2.1
-      to-buffer: 1.2.2
 
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
-
-  side-channel-list@1.0.1:
-    dependencies:
-      es-errors: 1.3.0
-      object-inspect: 1.13.4
-
-  side-channel-map@1.0.1:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      object-inspect: 1.13.4
-
-  side-channel-weakmap@1.0.2:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      object-inspect: 1.13.4
-      side-channel-map: 1.0.1
-
-  side-channel@1.1.0:
-    dependencies:
-      es-errors: 1.3.0
-      object-inspect: 1.13.4
-      side-channel-list: 1.0.1
-      side-channel-map: 1.0.1
-      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
@@ -4648,18 +3339,6 @@ snapshots:
 
   std-env@4.1.0: {}
 
-  stream-browserify@3.0.0:
-    dependencies:
-      inherits: 2.0.4
-      readable-stream: 3.6.2
-
-  stream-http@3.2.0:
-    dependencies:
-      builtin-status-codes: 3.0.0
-      inherits: 2.0.4
-      readable-stream: 3.6.2
-      xtend: 4.0.2
-
   string-argv@0.3.2: {}
 
   string-width@7.2.0:
@@ -4672,14 +3351,6 @@ snapshots:
     dependencies:
       get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
-
-  string_decoder@1.1.1:
-    dependencies:
-      safe-buffer: 5.1.2
-
-  string_decoder@1.3.0:
-    dependencies:
-      safe-buffer: 5.2.1
 
   strip-ansi@7.2.0:
     dependencies:
@@ -4695,10 +3366,6 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  timers-browserify@2.0.12:
-    dependencies:
-      setimmediate: 1.0.5
-
   tinybench@2.9.0: {}
 
   tinyexec@1.2.2: {}
@@ -4710,12 +3377,6 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
-  to-buffer@1.2.2:
-    dependencies:
-      isarray: 2.0.5
-      safe-buffer: 5.2.1
-      typed-array-buffer: 1.0.3
-
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
       typescript: 6.0.3
@@ -4723,17 +3384,9 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
-  tty-browserify@0.0.1: {}
-
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
-
-  typed-array-buffer@1.0.3:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      is-typed-array: 1.1.15
 
   typescript-eslint@8.59.4(eslint@10.4.0)(typescript@6.0.3):
     dependencies:
@@ -4779,40 +3432,11 @@ snapshots:
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
-  unzipit@1.4.3:
-    dependencies:
-      uzip-module: 1.0.3
-
   unzipit@2.0.0: {}
 
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
-
-  url@0.11.4:
-    dependencies:
-      punycode: 1.4.1
-      qs: 6.15.2
-
-  util-deprecate@1.0.2: {}
-
-  util@0.12.5:
-    dependencies:
-      inherits: 2.0.4
-      is-arguments: 1.2.0
-      is-generator-function: 1.1.2
-      is-typed-array: 1.1.15
-      which-typed-array: 1.1.20
-
-  uzip-module@1.0.3: {}
-
-  vite-plugin-node-polyfills@0.28.0(vite@8.0.14(yaml@2.9.0)):
-    dependencies:
-      "@rollup/plugin-inject": 5.0.5
-      node-stdlib-browser: 1.3.1
-      vite: 8.0.14(yaml@2.9.0)
-    transitivePeerDependencies:
-      - rollup
 
   vite@8.0.14(yaml@2.9.0):
     dependencies:
@@ -4852,21 +3476,9 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vm-browserify@1.1.2: {}
-
   vscode-uri@3.1.0: {}
 
   webpack-virtual-modules@0.6.2: {}
-
-  which-typed-array@1.1.20:
-    dependencies:
-      available-typed-arrays: 1.0.7
-      call-bind: 1.0.9
-      call-bound: 1.0.4
-      for-each: 0.3.5
-      get-proto: 1.0.1
-      gopd: 1.2.0
-      has-tostringtag: 1.0.2
 
   which@2.0.2:
     dependencies:
@@ -4891,14 +3503,12 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
 
-  xtend@4.0.2: {}
-
   yaml@2.9.0:
     optional: true
 
   yocto-queue@0.1.0: {}
 
-  zarrita@0.5.4:
+  zarrita@0.7.5:
     dependencies:
-      "@zarrita/storage": 0.1.4
+      "@zarrita/storage": 0.2.0
       numcodecs: 0.3.2

--- a/src/OMEZarrTileSource.ts
+++ b/src/OMEZarrTileSource.ts
@@ -1,30 +1,75 @@
-import { ZipFileStore } from "@zarrita/storage";
-import { type Multiscale, type Omero, renderImage } from "ome-zarr.js";
+import { NgffImage, getMinMaxValues } from "ome-zarr.js";
 import OpenSeadragon from "openseadragon";
 import * as zarr from "zarrita";
 
+import { toContext2D } from "./utils/canvas";
+import {
+  type Axis,
+  getActiveChannels,
+  isAxis,
+  renderPlanes,
+} from "./utils/ngff";
+import {
+  type ZarrArray,
+  type ZarrChunk,
+  copyChunk,
+  getPlane,
+  openStore,
+} from "./utils/zarr";
+
+/** Constructor type of {@link OMEZarrTileSource}. */
 export type OMEZarrTileSourceClass = typeof OMEZarrTileSource;
 declare module "openseadragon" {
+  /** Set by {@link OMEZarrTileSource.enable}. */
   let OMEZarrTileSource: OMEZarrTileSourceClass;
 }
 
-type UserData = {
-  abortController?: AbortController;
-  img?: HTMLImageElement;
-};
-
+/** Options for {@link OMEZarrTileSource}. */
 export interface OMEZarrTileSourceOptions {
+  /** Tile source type, required for inline configuration in OpenSeadragon. */
   type?: "ome-zarr";
-  url: string; // TileSource.url
+  /** URL of the OME-Zarr image, i.e. the group holding the `multiscales` metadata. */
+  url: string;
+  /**
+   * Whether the image is a zipped OME-Zarr (`.ozx`) to be read via HTTP range
+   * requests. Detected from the `.ozx` suffix if omitted.
+   */
   zip?: boolean;
+  /** Time point to show; the omero default or the middle plane if omitted. */
   t?: number;
+  /** Channel to render; all channels marked active in the omero metadata if omitted. */
   c?: number;
+  /** Z-slice to show; the omero default or the middle plane if omitted. */
   z?: number;
+  /**
+   * Data type produced per tile:
+   * - `"context2d"` (default): tiles rendered by ome-zarr.js according to the
+   *   omero metadata, as `CanvasRenderingContext2D`.
+   * - `"zarrChunk"`: raw zarrita chunks of the tile region, with the same rank
+   *   as the image arrays (fixed t/z/c axes have length 1). OpenSeadragon
+   *   renders them via the converter learned by
+   *   {@link OMEZarrTileSource.learnDataTypes}.
+   */
+  dataType?: "context2d" | "zarrChunk";
 }
 
-export class OMEZarrTileSource extends OpenSeadragon.TileSource {
-  static readonly DUMMY_XHR = new XMLHttpRequest();
+/** Per-tile state stored on OpenSeadragon's ImageJob. */
+type UserData = {
+  abortController?: AbortController;
+};
 
+/** OpenSeadragon instances whose converter already knows the data types. */
+const learnedOpenSeadragons = new WeakSet<typeof OpenSeadragon>();
+
+/**
+ * OpenSeadragon tile source for OME-Zarr images (v0.4 and v0.5).
+ *
+ * Each resolution level of the image is one OpenSeadragon level (level 0 being
+ * the smallest), tiled by the zarr chunk size. Tiles are either rendered with
+ * ome-zarr.js or delivered as raw zarrita chunks, see
+ * {@link OMEZarrTileSourceOptions.dataType}.
+ */
+export class OMEZarrTileSource extends OpenSeadragon.TileSource {
   // properties inherited from/required by OpenSeadragon.TileSource
   readonly url: string;
   width: number = 10; // required starting from OpenSeadragon 6 (previously optional)
@@ -34,37 +79,42 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
   maxLevel: number = 0;
   ready: boolean = false;
 
+  /** See {@link OMEZarrTileSourceOptions.zip}. */
   readonly zip?: boolean;
+  /** See {@link OMEZarrTileSourceOptions.t}. */
   readonly t?: number;
+  /** See {@link OMEZarrTileSourceOptions.c}. */
   readonly c?: number;
+  /** See {@link OMEZarrTileSourceOptions.z}. */
   readonly z?: number;
-  private _omero?: Omero;
-  private _multiscale?: Multiscale;
-  private _axisIndices?: {
-    t?: number;
-    c?: number;
-    z?: number;
-    y: number;
-    x: number;
+  /** See {@link OMEZarrTileSourceOptions.dataType}. */
+  readonly dataType: "context2d" | "zarrChunk";
+  /** Loaded image, its axes and arrays by level (smallest first); set once ready. */
+  private _image?: {
+    img: NgffImage;
+    axes: Axis[];
+    arrays: ZarrArray[];
   };
-  private _arrays?: zarr.Array<zarr.DataType>[];
 
+  /**
+   * Creates a tile source and starts loading the image, see
+   * {@link getImageInfo}.
+   */
   constructor(url: string);
   constructor(options: OMEZarrTileSourceOptions);
   constructor(config: string | OMEZarrTileSourceOptions) {
-    if (typeof config === "string") {
-      super(config); // invokes getImageInfo
-      this.url = config;
-    } else {
-      super(config.url); // invokes getImageInfo
-      this.url = config.url;
-      this.zip = config.zip;
-      this.t = config.t;
-      this.c = config.c;
-      this.z = config.z;
-    }
+    const options = typeof config === "string" ? { url: config } : config;
+    super(options.url); // invokes getImageInfo
+    this.url = options.url;
+    this.zip = options.zip;
+    this.t = options.t;
+    this.c = options.c;
+    this.z = options.z;
+    this.dataType = options.dataType ?? "context2d";
+    OMEZarrTileSource.learnDataTypes();
   }
 
+  /** Whether `data` is a `.ozx` URL or an inline `{ type: "ome-zarr" }` configuration. */
   supports(data: string | object | object[] | Document): boolean {
     if (Array.isArray(data) || data instanceof Document) {
       return false;
@@ -75,6 +125,7 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
     return "type" in data && data.type === "ome-zarr";
   }
 
+  /** Normalizes a supported inline configuration to {@link OMEZarrTileSourceOptions}. */
   configure(
     data: string | object | object[] | Document,
     _url: string,
@@ -95,6 +146,7 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
     return { type: "ome-zarr", ...(data as OMEZarrTileSourceOptions) };
   }
 
+  /** Whether `other` is an OME-Zarr tile source with the same options. */
   equals(other: OpenSeadragon.TileSource): boolean {
     return (
       other instanceof OMEZarrTileSource &&
@@ -102,53 +154,24 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
       this.zip === other.zip &&
       this.t === other.t &&
       this.c === other.c &&
-      this.z === other.z
+      this.z === other.z &&
+      this.dataType === other.dataType
     );
   }
 
+  /**
+   * Loads the image metadata and arrays, then raises `ready`, or `open-failed`
+   * on error. Called by OpenSeadragon upon construction.
+   */
   getImageInfo(url: string): void {
     console.debug(`getting image info for ${url}`);
-    const store =
-      this.zip || (this.zip === undefined && url.endsWith(".ozx"))
-        ? ZipFileStore.fromUrl(url)
-        : new zarr.FetchStore(url);
-    zarr
-      .open(store, { kind: "group" })
-      .then(async (group) => {
-        console.debug(`opened group for ${url}`);
-        const { multiscale, omero } = OMEZarrTileSource._getMultiscale(group);
-        const axisIndices = OMEZarrTileSource._getAxisIndices(multiscale);
-        const arrays = await Promise.all(
-          multiscale.datasets.map((dataset) =>
-            zarr.open(group.resolve(dataset.path), { kind: "array" }),
-          ),
-        );
-        console.debug(`opened ${arrays.length} arrays for ${url}`);
-        const maxWidth = arrays[0]!.shape[axisIndices.x]!;
-        const maxHeight = arrays[0]!.shape[axisIndices.y]!;
-        this._omero = omero;
-        this._multiscale = multiscale;
-        this._axisIndices = axisIndices;
-        this._arrays = arrays;
-        this.width = maxWidth;
-        this.height = maxHeight;
-        this.aspectRatio = maxWidth / maxHeight;
-        this.dimensions = new OpenSeadragon.Point(maxWidth, maxHeight);
-        this.maxLevel = arrays.length - 1;
-        this.ready = true;
+    this._open(url)
+      .then(() => {
         console.debug(`ready for ${url}`);
         this.raiseEvent("ready", { tileSource: this });
       })
       .catch((reason) => {
-        this._omero = undefined;
-        this._multiscale = undefined;
-        this._axisIndices = undefined;
-        this._arrays = undefined;
-        this.width = 10;
-        this.height = 10;
-        this.aspectRatio = 1;
-        this.dimensions = new OpenSeadragon.Point(10, 10);
-        this.maxLevel = 0;
+        this._image = undefined;
         this.ready = false;
         const message = `failed to get image info for ${url}: ${reason}`;
         console.error(message);
@@ -156,211 +179,286 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
       });
   }
 
+  /** Tile width at `level`, i.e. the chunk size of its array along x. */
   getTileWidth(level: number): number {
-    if (this._axisIndices === undefined || this._arrays === undefined) {
-      throw new Error("tile source not ready");
-    }
-    if (level < 0 || level > this.maxLevel) {
-      throw new Error("level out of bounds");
-    }
-    const array = this._arrays[this.maxLevel - level]!;
-    return array.chunks[this._axisIndices.x]!;
+    return this._getArray(level).chunks[this._axis("x")]!;
   }
 
+  /** Tile height at `level`, i.e. the chunk size of its array along y. */
   getTileHeight(level: number): number {
-    if (this._axisIndices === undefined || this._arrays === undefined) {
-      throw new Error("tile source not ready");
-    }
-    if (level < 0 || level > this.maxLevel) {
-      throw new Error("level out of bounds");
-    }
-    const array = this._arrays[this.maxLevel - level]!;
-    return array.chunks[this._axisIndices.y]!;
+    return this._getArray(level).chunks[this._axis("y")]!;
   }
 
+  /** Width of `level` relative to the full resolution. */
   getLevelScale(level: number): number {
-    if (this._axisIndices === undefined || this._arrays === undefined) {
-      throw new Error("tile source not ready");
-    }
-    if (level < 0 || level > this.maxLevel) {
-      throw new Error("level out of bounds");
-    }
-    const array = this._arrays[this.maxLevel - level]!;
-    const arrayWidth = array.shape[this._axisIndices.x]!;
-    const maxWidth = this._arrays[0]!.shape[this._axisIndices.x]!;
-    return arrayWidth / maxWidth;
+    return this._getSize(level, "x") / this._getSize(this.maxLevel, "x");
   }
 
+  /** Tile identifier (`level=…&x=…&y=…`), parsed again by {@link downloadTileStart}. */
   getTileUrl(level: number, x: number, y: number): string {
-    const urlSearchParams = new URLSearchParams();
-    urlSearchParams.append("level", level.toString());
-    urlSearchParams.append("x", x.toString());
-    urlSearchParams.append("y", y.toString());
-    return urlSearchParams.toString();
+    return new URLSearchParams({
+      level: `${level}`,
+      x: `${x}`,
+      y: `${y}`,
+    }).toString();
   }
 
+  /** Cache key: the image URL plus tile coordinates, plane and data type. */
   getTileHashKey(level: number, x: number, y: number): string {
     const url = new URL(this.url);
-    url.searchParams.append("level", level.toString());
-    url.searchParams.append("x", x.toString());
-    url.searchParams.append("y", y.toString());
-    if (this.z !== undefined) {
-      url.searchParams.append("z", this.z.toString());
+    const params = { level, x, y, z: this.z, c: this.c, t: this.t };
+    for (const [name, value] of Object.entries(params)) {
+      if (value !== undefined) {
+        url.searchParams.append(name, `${value}`);
+      }
     }
-    if (this.c !== undefined) {
-      url.searchParams.append("c", this.c.toString());
-    }
-    if (this.t !== undefined) {
-      url.searchParams.append("t", this.t.toString());
-    }
+    url.searchParams.append("dataType", this.dataType);
     return url.toString();
   }
 
+  /**
+   * Loads the tile identified by `context.src` and finishes the job with data
+   * of type {@link dataType}. Abortable via {@link downloadTileAbort}.
+   */
   downloadTileStart(context: OpenSeadragon.ImageJob): void {
-    const userData = context.userData as UserData;
     const abortController = new AbortController();
-    userData.abortController = abortController;
-    const urlSearchParams = new URLSearchParams(context.src);
-    const level = +urlSearchParams.get("level")!;
-    const x = +urlSearchParams.get("x")!;
-    const y = +urlSearchParams.get("y")!;
-    try {
-      if (
-        this._multiscale === undefined ||
-        this._axisIndices === undefined ||
-        this._arrays === undefined
-      ) {
-        throw new Error("tile source not ready");
-      }
-      console.debug(
-        `downloading tile for level=${level}, x=${x}, y=${y} from dataset ${this.maxLevel - level}`,
-      );
-      const tileWidth = this.getTileWidth(level);
-      const tileHeight = this.getTileHeight(level);
-      const array = this._arrays[this.maxLevel - level]!;
-      const maxTileWidth = array.shape[this._axisIndices.x]!;
-      const maxTileHeight = array.shape[this._axisIndices.y]!;
-      renderImage(array, this._multiscale.axes, this._omero, {
-        x: [x * tileWidth, Math.min((x + 1) * tileWidth, maxTileWidth)],
-        y: [y * tileHeight, Math.min((y + 1) * tileHeight, maxTileHeight)],
-        z: this.z,
-        c: this.c,
-        t: this.t,
-      }) // TODO https://github.com/BioNGFF/ome-zarr.js/pull/26
-        .then(async (dataUrl) => {
-          abortController.signal.throwIfAborted();
-          console.debug(`rendered tile for level=${level}, x=${x}, y=${y}`);
-          const img = await new Promise<HTMLImageElement>((resolve, reject) => {
-            const img = new Image();
-            userData.img = img;
-            img.onload = () => resolve(img);
-            img.onerror = (reason) => reject(new Error(reason as string));
-            img.onabort = () => {
-              if (!abortController.signal.aborted) {
-                abortController.abort();
-              }
-              const reason = abortController.signal.reason as unknown;
-              reject(
-                reason instanceof Error ? reason : new Error(String(reason)),
-              );
-            };
-            img.src = dataUrl;
-          });
-          abortController.signal.throwIfAborted();
-          console.debug(`loaded tile for level=${level}, x=${x}, y=${y}`);
-          context.finish(img, OMEZarrTileSource.DUMMY_XHR, "image");
-        })
-        .catch((reason) => {
-          if (abortController.signal.aborted) {
-            console.debug(
-              `aborted tile rendering for level=${level}, x=${x}, y=${y}`,
-            );
-          } else {
-            const message = `failed to render tile for level=${level}, x=${x}, y=${y}: ${reason}`;
-            console.error(message);
-            context.fail(message, OMEZarrTileSource.DUMMY_XHR);
-          }
-        });
-    } catch (error) {
-      const message = `failed to download tile for level=${level}, x=${x}, y=${y}: ${String(error)}`;
-      console.error(message);
-      context.fail(message, OMEZarrTileSource.DUMMY_XHR);
-    }
+    (context.userData as UserData).abortController = abortController;
+    const params = new URLSearchParams(context.src);
+    const level = Number(params.get("level"));
+    const x = Number(params.get("x"));
+    const y = Number(params.get("y"));
+    const tile = `level=${level}, x=${x}, y=${y}`;
+    console.debug(`downloading tile for ${tile}`);
+    this._downloadTile(level, x, y, abortController.signal)
+      .then((data) => {
+        abortController.signal.throwIfAborted();
+        context.finish(data, null, this.dataType);
+      })
+      .catch((reason) => {
+        if (abortController.signal.aborted) {
+          console.debug(`aborted tile for ${tile}`);
+          return;
+        }
+        const message = `failed to download tile for ${tile}: ${reason}`;
+        console.error(message);
+        context.fail(message, null);
+      });
   }
 
+  /** Aborts a tile download started by {@link downloadTileStart}. */
   downloadTileAbort(context: OpenSeadragon.ImageJob): void {
-    const userData = context.userData as UserData;
-    if (userData.abortController !== undefined) {
-      userData.abortController.abort();
-      userData.abortController = undefined;
-    }
-    if (userData.img !== undefined) {
-      userData.img.src = "";
-      userData.img = undefined;
-    }
+    (context.userData as UserData).abortController?.abort();
   }
 
+  /**
+   * Registers the class as `OpenSeadragon.OMEZarrTileSource`, enabling inline
+   * `{ type: "ome-zarr" }` configuration, and learns the data types.
+   */
   static enable(os: typeof OpenSeadragon = OpenSeadragon): void {
     os.OMEZarrTileSource = OMEZarrTileSource;
+    OMEZarrTileSource.learnDataTypes(os);
   }
 
-  // TODO https://github.com/BioNGFF/ome-zarr.js/pull/27
-  private static _getMultiscale<T extends zarr.Readable>(
-    group: zarr.Group<T>,
-  ): { multiscale: Multiscale; omero?: Omero } {
-    let metadata = group.attrs as Record<string, unknown>;
-    if ("ome" in metadata) {
-      metadata = metadata["ome"] as Record<string, unknown>;
+  /**
+   * Teaches OpenSeadragon's data type converter the `"zarrChunk"` data type
+   * (see {@link OMEZarrTileSourceOptions.dataType}): how to copy it and how to
+   * render it to a `"context2d"` using the omero metadata of the tile's
+   * source. Called by the constructor and by {@link enable}; idempotent.
+   */
+  static learnDataTypes(os: typeof OpenSeadragon = OpenSeadragon): void {
+    if (learnedOpenSeadragons.has(os)) {
+      return;
     }
-    if (!("multiscales" in metadata)) {
-      throw new Error("missing OME-Zarr multiscales metadata");
-    }
-    const multiscales = metadata["multiscales"] as Multiscale[];
-    if (multiscales.length === 0) {
-      throw new Error("empty OME-Zarr multiscales metadata");
-    }
-    const multiscale = multiscales[0]!;
-    const omero = metadata["omero"] as Omero | undefined;
-    return { multiscale, omero };
+    learnedOpenSeadragons.add(os);
+    os.converter.learn(
+      "zarrChunk",
+      "context2d",
+      (tile: OpenSeadragon.Tile, chunk: ZarrChunk) => {
+        const source = tile.tiledImage?.source;
+        if (!(source instanceof OMEZarrTileSource)) {
+          throw new Error("zarrChunk does not belong to an OME-Zarr tile");
+        }
+        return source._renderChunk(chunk);
+      },
+      1,
+      2,
+    );
+    os.converter.learn(
+      "zarrChunk",
+      "zarrChunk",
+      (_tile: OpenSeadragon.Tile, chunk: ZarrChunk) => copyChunk(chunk),
+      1,
+      1,
+    );
   }
 
-  private static _getAxisIndices(multiscale: Multiscale): {
-    t?: number;
-    c?: number;
-    z?: number;
-    y: number;
-    x: number;
-  } {
-    let t: number | undefined = undefined;
-    let c: number | undefined = undefined;
-    let z: number | undefined = undefined;
-    let y: number | undefined = undefined;
-    let x: number | undefined = undefined;
-    for (let i = 0; i < multiscale.axes.length; i++) {
-      const axis = multiscale.axes[i]!;
-      switch (axis.name) {
-        case "t":
-          t = i;
-          break;
-        case "c":
-          c = i;
-          break;
-        case "z":
-          z = i;
-          break;
-        case "y":
-          y = i;
-          break;
+  /** Opens the image and its arrays and initializes the tile source from them. */
+  private async _open(url: string): Promise<void> {
+    const img = await NgffImage.load(openStore(url, this.zip));
+    const axes = img.getAxesNames();
+    if (!axes.every(isAxis) || !axes.includes("x") || !axes.includes("y")) {
+      throw new Error(`unsupported axes: ${axes.join(", ")}`);
+    }
+    const arrays = await Promise.all(
+      img.paths.map((_, i) => img.openArray(i) as Promise<ZarrArray>),
+    );
+    console.debug(`opened ${arrays.length} arrays for ${url}`);
+    this._image = { img, axes, arrays: arrays.reverse() };
+    this.maxLevel = arrays.length - 1;
+    await this._completeChannelWindows();
+    this.width = this._getSize(this.maxLevel, "x");
+    this.height = this._getSize(this.maxLevel, "y");
+    this.aspectRatio = this.width / this.height;
+    this.dimensions = new OpenSeadragon.Point(this.width, this.height);
+    this.ready = true;
+  }
+
+  /**
+   * Fills in missing channel window start/end values once from the smallest
+   * resolution level, so that all tiles are rendered with the same range.
+   */
+  private async _completeChannelWindows(): Promise<void> {
+    const channels = this._loaded.img.omero?.channels ?? [];
+    await Promise.all(
+      channels.map(async ({ window }, c) => {
+        if (window.start === undefined || window.end === undefined) {
+          const selection = this._getSelection(0, { c });
+          const plane = await zarr.get(this._getArray(0), selection);
+          const [min, max] = getMinMaxValues(plane);
+          window.start ??= min;
+          window.end ??= Math.max(max, window.start + 1);
+        }
+      }),
+    );
+  }
+
+  /** Loads the data of a tile as {@link dataType}. */
+  private async _downloadTile(
+    level: number,
+    x: number,
+    y: number,
+    signal: AbortSignal,
+  ) {
+    const array = this._getArray(level);
+    if (this.dataType === "zarrChunk") {
+      return zarr.get(array, this._getSelection(level, { x, y }), { signal });
+    }
+    const { data, width, height } = await this._loaded.img.renderArray({
+      arr: array,
+      slices: {
+        x: this._getTileRange(level, "x", x),
+        y: this._getTileRange(level, "y", y),
+        z: this.z,
+        t: this.t,
+      },
+      channels: this._getChannels(),
+      signal,
+    });
+    return toContext2D(data, width, height);
+  }
+
+  /** Renders a `"zarrChunk"` tile of this tile source to a 2D context. */
+  private _renderChunk(chunk: ZarrChunk): CanvasRenderingContext2D {
+    const height = chunk.shape[this._axis("y")]!;
+    const width = chunk.shape[this._axis("x")]!;
+    const channels = getActiveChannels(this._getChannels());
+    // the chunk's c axis holds either all channels or only channel `c`
+    const stride =
+      this.c === undefined ? (chunk.stride[this._axis("c")] ?? 0) : 0;
+    const planes = channels.map(({ index }) =>
+      getPlane(chunk, index * stride, height, width),
+    );
+    return toContext2D(renderPlanes(planes, channels), width, height);
+  }
+
+  /** Omero channels of the image; only channel {@link c} is active if set. */
+  private _getChannels() {
+    const channels = this._loaded.img.omero?.channels ?? [];
+    return this.c === undefined
+      ? channels
+      : channels.map((channel, i) => ({ ...channel, active: i === this.c }));
+  }
+
+  /**
+   * Full-rank zarrita selection of a tile at `level`, or of the whole plane if
+   * the tile coordinates are omitted. Fixed t/z/c axes are sliced to length 1,
+   * other axes are selected entirely.
+   */
+  private _getSelection(
+    level: number,
+    { x, y, c = this.c }: { x?: number; y?: number; c?: number } = {},
+  ): (zarr.Slice | null)[] {
+    const range = (start: number, stop = start + 1) => zarr.slice(start, stop);
+    return this._loaded.axes.map((axis) => {
+      switch (axis) {
         case "x":
-          x = i;
-          break;
+          return x === undefined
+            ? null
+            : range(...this._getTileRange(level, "x", x));
+        case "y":
+          return y === undefined
+            ? null
+            : range(...this._getTileRange(level, "y", y));
+        case "c":
+          return c === undefined ? null : range(c);
         default:
-          throw new Error(`unsupported axis: ${axis.name}`);
+          return range(this._getPlaneIndex(level, axis));
       }
+    });
+  }
+
+  /**
+   * Index of the t/z plane to show at `level`: the configured or omero default
+   * index, rescaled like ome-zarr.js does if the level has a different size
+   * along that axis, or the middle plane if unspecified.
+   */
+  private _getPlaneIndex(level: number, axis: "t" | "z"): number {
+    const rdefs = this._loaded.img.omero?.rdefs;
+    const index =
+      axis === "z" ? (this.z ?? rdefs?.defaultZ) : (this.t ?? rdefs?.defaultT);
+    const size = this._getSize(level, axis);
+    if (index === undefined) {
+      return Math.floor(size / 2);
     }
-    if (x === undefined || y === undefined) {
-      throw new Error("missing X or Y axis");
+    return Math.floor((index * size) / this._getSize(this.maxLevel, axis));
+  }
+
+  /** Pixel range `[start, stop)` covered by tile `index` along `axis` at `level`. */
+  private _getTileRange(
+    level: number,
+    axis: "x" | "y",
+    index: number,
+  ): [number, number] {
+    const tileSize =
+      axis === "x" ? this.getTileWidth(level) : this.getTileHeight(level);
+    const size = this._getSize(level, axis);
+    return [index * tileSize, Math.min((index + 1) * tileSize, size)];
+  }
+
+  /** Size of the array at `level` along `axis`. */
+  private _getSize(level: number, axis: Axis): number {
+    return this._getArray(level).shape[this._axis(axis)]!;
+  }
+
+  /** Array of the given level. */
+  private _getArray(level: number): ZarrArray {
+    const array = this._loaded.arrays[level];
+    if (array === undefined) {
+      throw new Error("level out of bounds");
     }
-    return { t, c, z, y, x };
+    return array;
+  }
+
+  /** Index of the named axis, or -1 if the image has no such axis. */
+  private _axis(name: Axis): number {
+    return this._loaded.axes.indexOf(name);
+  }
+
+  /** The loaded image state; throws if the tile source is not ready. */
+  private get _loaded() {
+    if (this._image === undefined) {
+      throw new Error("tile source not ready");
+    }
+    return this._image;
   }
 }

--- a/src/OMEZarrTileSource.ts
+++ b/src/OMEZarrTileSource.ts
@@ -46,11 +46,6 @@ export interface OMEZarrTileSourceOptions {
   dataType?: "context2d" | "zarrChunk";
 }
 
-/** Per-tile state stored on OpenSeadragon's ImageJob. */
-type UserData = {
-  abortController?: AbortController;
-};
-
 /** OpenSeadragon instances whose converter already knows the data types. */
 const learnedOpenSeadragons = new WeakSet<typeof OpenSeadragon>();
 
@@ -215,7 +210,9 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
    */
   downloadTileStart(context: OpenSeadragon.ImageJob): void {
     const abortController = new AbortController();
-    (context.userData as UserData).abortController = abortController;
+    (
+      context.userData as { abortController?: AbortController }
+    ).abortController = abortController;
     const params = new URLSearchParams(context.src);
     const level = Number(params.get("level"));
     const x = Number(params.get("x"));
@@ -240,7 +237,9 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
 
   /** Aborts a tile download started by {@link downloadTileStart}. */
   downloadTileAbort(context: OpenSeadragon.ImageJob): void {
-    (context.userData as UserData).abortController?.abort();
+    (
+      context.userData as { abortController?: AbortController }
+    ).abortController?.abort();
   }
 
   /**

--- a/src/OMEZarrTileSource.ts
+++ b/src/OMEZarrTileSource.ts
@@ -17,13 +17,6 @@ import {
   openStore,
 } from "./utils/zarr";
 
-/** Constructor type of {@link OMEZarrTileSource}. */
-export type OMEZarrTileSourceClass = typeof OMEZarrTileSource;
-declare module "openseadragon" {
-  /** Set by {@link OMEZarrTileSource.enable}. */
-  let OMEZarrTileSource: OMEZarrTileSourceClass;
-}
-
 /** Options for {@link OMEZarrTileSource}. */
 export interface OMEZarrTileSourceOptions {
   /** Tile source type, required for inline configuration in OpenSeadragon. */
@@ -255,7 +248,7 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
    * `{ type: "ome-zarr" }` configuration, and learns the data types.
    */
   static enable(os: typeof OpenSeadragon = OpenSeadragon): void {
-    os.OMEZarrTileSource = OMEZarrTileSource;
+    Object.assign(os, { OMEZarrTileSource });
     OMEZarrTileSource.learnDataTypes(os);
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ export {
   type OMEZarrTileSourceOptions,
 } from "./OMEZarrTileSource";
 
+// enable automatically when OpenSeadragon is loaded globally, e.g. via CDN
 if (globalThis.OpenSeadragon) {
   OMEZarrTileSource.enable(globalThis.OpenSeadragon);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,6 @@ import { OMEZarrTileSource } from "./OMEZarrTileSource";
 
 export {
   OMEZarrTileSource,
-  type OMEZarrTileSourceClass,
   type OMEZarrTileSourceOptions,
 } from "./OMEZarrTileSource";
 

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -1,0 +1,17 @@
+/** Draws RGBA pixel `data` of the given size onto a new canvas and returns its 2D context. */
+export function toContext2D(
+  data: Uint8ClampedArray,
+  width: number,
+  height: number,
+): CanvasRenderingContext2D {
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+  const context = canvas.getContext("2d")!;
+  context.putImageData(
+    new ImageData(data as Uint8ClampedArray<ArrayBuffer>, width, height),
+    0,
+    0,
+  );
+  return context;
+}

--- a/src/utils/ngff.ts
+++ b/src/utils/ngff.ts
@@ -1,0 +1,59 @@
+import { type Channel, getMinMaxValues, renderChunks } from "ome-zarr.js";
+
+import type { ZarrChunk } from "./zarr";
+
+/** Supported OME-NGFF axis names. */
+export type Axis = "t" | "c" | "z" | "y" | "x";
+
+/** All supported OME-NGFF axis names. */
+export const AXES: Axis[] = ["t", "c", "z", "y", "x"];
+
+/** Whether `name` is a supported OME-NGFF axis name. */
+export function isAxis(name: string): name is Axis {
+  return AXES.includes(name as Axis);
+}
+
+/** Maximum number of channels rendered at once, as in ome-zarr.js. */
+export const MAX_ACTIVE_CHANNELS = 3;
+
+/**
+ * The channels to render, i.e. the first {@link MAX_ACTIVE_CHANNELS} channels
+ * not marked inactive, each with its index in `channels`.
+ */
+export function getActiveChannels(
+  channels: Channel[],
+): (Channel & { index: number })[] {
+  return channels
+    .map((channel, index) => ({ ...channel, index }))
+    .filter((channel) => channel.active ?? true)
+    .slice(0, MAX_ACTIVE_CHANNELS);
+}
+
+/** Parses an RGB hex color such as `"#ff8800"` or `"FF8800"`. */
+export function hexToRgb(color: string): [number, number, number] {
+  const rgb = parseInt(color.replace(/^#/, ""), 16);
+  return [(rgb >> 16) & 0xff, (rgb >> 8) & 0xff, rgb & 0xff];
+}
+
+/**
+ * Additively renders one 2D plane per channel to RGBA, applying the channel's
+ * window (or the plane's min/max if the window has no start/end), color,
+ * LUT or colormap, and inversion.
+ */
+export function renderPlanes(
+  planes: ZarrChunk[],
+  channels: Channel[],
+): Uint8ClampedArray {
+  return renderChunks(
+    planes,
+    channels.map(({ window }, i): [number, number] =>
+      window.start !== undefined && window.end !== undefined
+        ? [window.start, window.end]
+        : getMinMaxValues(planes[i]),
+    ),
+    channels.map(({ color }) => hexToRgb(color)),
+    channels.map(({ lut, colorMap }) => lut ?? colorMap),
+    channels.map(({ inverted }) => !!inverted),
+    false,
+  );
+}

--- a/src/utils/zarr.ts
+++ b/src/utils/zarr.ts
@@ -1,0 +1,46 @@
+import ZipFileStore from "@zarrita/storage/zip";
+import * as zarr from "zarrita";
+
+/** A zarr array with numeric (or bigint) pixel data. */
+export type ZarrArray = zarr.Array<zarr.NumberDataType | zarr.BigintDataType>;
+
+/** In-memory data read from a {@link ZarrArray}. */
+export type ZarrChunk = zarr.Chunk<zarr.NumberDataType | zarr.BigintDataType>;
+
+/**
+ * Opens a read-only store for `url`: a zipped OME-Zarr read via HTTP range
+ * requests if `zip` is set (or the URL ends with `.ozx`), an HTTP store
+ * otherwise.
+ */
+export function openStore(
+  url: string,
+  zip: boolean = url.endsWith(".ozx"),
+): zarr.Readable {
+  return zip ? ZipFileStore.fromUrl(url) : new zarr.FetchStore(url);
+}
+
+/** Deep copy of `chunk`. */
+export function copyChunk(chunk: ZarrChunk): ZarrChunk {
+  return {
+    data: chunk.data.slice(),
+    shape: [...chunk.shape],
+    stride: [...chunk.stride],
+  };
+}
+
+/**
+ * The 2D (y, x) plane of a C-ordered `chunk` starting at element `offset`.
+ * The plane shares its memory with the chunk.
+ */
+export function getPlane(
+  chunk: ZarrChunk,
+  offset: number,
+  height: number,
+  width: number,
+): ZarrChunk {
+  return {
+    data: chunk.data.subarray(offset, offset + width * height),
+    shape: [height, width],
+    stride: [width, 1],
+  };
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,5 @@
 import dts from "unplugin-dts/vite";
 import { defineConfig } from "vite";
-import { nodePolyfills } from "vite-plugin-node-polyfills";
 
 export default defineConfig(({ mode }) => {
   if (mode === "library") {
@@ -21,7 +20,7 @@ export default defineConfig(({ mode }) => {
         },
         chunkSizeWarningLimit: 2048,
       },
-      plugins: [nodePolyfills(), dts({ bundleTypes: true })],
+      plugins: [dts({ bundleTypes: true })],
     };
   }
   return {
@@ -29,6 +28,5 @@ export default defineConfig(({ mode }) => {
     build: {
       chunkSizeWarningLimit: 2048,
     },
-    plugins: [nodePolyfills()],
   };
 });


### PR DESCRIPTION
Ports `OMEZarrTileSource` to the OpenSeadragon 6 data pipeline.

- Tiles are produced as `context2d` instead of PNG data URL → `image`
- New `dataType: "context2d" | "zarrChunk"` option; `zarrChunk` delivers raw zarrita chunks (full rank, aligned with the `multiscales` axes) and a registered `zarrChunk → context2d` converter keeps them renderable
- ome-zarr.js 0.0.20 (`renderArray` API) and zarrita 0.7.5; `ZipFileStore` imported from `@zarrita/storage/zip`, `vite-plugin-node-polyfills` dropped
- Missing channel window `start`/`end` derived once from the smallest level (consistent range across tiles); `c` option now honoured
- Helpers extracted to `src/utils`, TSDoc added, demo page shows both data types

**Breaking:** requires OpenSeadragon ≥ 6.

Verified with a Node/jsdom smoke test against the IDR `6001240_labels.zarr` image (both data types, converter parity, abort, edge tiles). Not yet checked in a real browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
