### PR TITLE
OpenSeadragon 6 data pipeline (release v0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Support for OpenSeadragon 5
+- `OMEZarrTileSource.DUMMY_XHR`; tile jobs now finish and fail with a `null` request
 
 ## [0.2.0] - 2026-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Require OpenSeadragon 6 or newer (peer dependency `>=6.0.0 <7.0.0`)
 - Updated OpenSeadragon to 6.1.1
 - Updated ome-zarr.js to 0.0.20 and zarrita to 0.7.5
-- Switched from the deprecated `renderImage` function to the `NgffImage.render` API
+- Switched from the deprecated `renderImage` function to the `NgffImage.renderArray` API
+- Tiles are passed to OpenSeadragon as 2D canvas contexts instead of PNG images, skipping the PNG encode/decode per tile
 - Aborted tile downloads now also cancel the underlying chunk requests
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Removed
+
+## [0.3.0] - 2026-09-11
+
+### Added
+
 - OpenSeadragon data type `ome-zarr` (see `OMEZarrTileData`) with converters to `context2d` and for copying
 - Option `dataType` to choose between `context2d` tiles rendered by the tile source (default; composite of all active channels for multi-channel images without `c`) and raw `ome-zarr` tile data
 - Option `autoBoost` to boost the brightness of dark tiles (ome-zarr.js `renderChunks` autoBoost)
@@ -84,7 +92,8 @@ Complete package.json
 
 Initial release
 
-[unreleased]: https://github.com/TissUUmaps/OMEZarrTileSource/compare/v0.2.0...HEAD
+[unreleased]: https://github.com/TissUUmaps/OMEZarrTileSource/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/TissUUmaps/OMEZarrTileSource/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/TissUUmaps/OMEZarrTileSource/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/TissUUmaps/OMEZarrTileSource/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/TissUUmaps/OMEZarrTileSource/compare/v0.0.3...v0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Require OpenSeadragon 6 or newer (peer dependency `>=6.0.0 <7.0.0`)
+- Updated OpenSeadragon to 6.1.1
+
 ### Removed
+
+- Support for OpenSeadragon 5
 
 ## [0.2.0] - 2026-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - OpenSeadragon data type `ome-zarr` (see `OMEZarrTileData`) with converters to `context2d` and for copying
-- Options `color`, `colorLUT`, `colorMap`, `contrastLimits` and `inverted` to override the channel rendering settings from the omero metadata
+- Option `dataType` to choose between `context2d` tiles rendered by the tile source (default; composite of all active channels for multi-channel images without `c`) and raw `ome-zarr` tile data
 - Option `autoBoost` to boost the brightness of dark tiles (ome-zarr.js `renderChunks` autoBoost)
 
 ### Changed
@@ -19,8 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated OpenSeadragon to 6.1.1
 - Updated ome-zarr.js to 0.0.20 and zarrita to 0.7.5
 - Switched from the deprecated `renderImage` function to `NgffImage` for loading and `getSlices`/`renderChunks` for rendering
-- Tiles are downloaded as raw single-channel zarrita chunks (OpenSeadragon data type `ome-zarr`) and rendered to `context2d` by a registered converter, so tiles can be re-rendered from cache without re-downloading
-- Multi-channel images require the `c` option
+- Tiles are rendered by the tile source (`dataType` `"context2d"`, default) or downloaded as raw single-channel zarrita chunks (`dataType` `"ome-zarr"`) that are rendered to `context2d` by a registered converter, so tiles can be re-rendered from cache without re-downloading
+- Images with the X axis before the Y axis are rejected
+- Images whose omero metadata lists a different number of channels than the image has are rejected
+- Multi-channel images require the `c` option for `dataType` `"ome-zarr"`
 - Aborted tile downloads now also cancel the underlying chunk requests
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for OpenSeadragon 5
 - `OMEZarrTileSource.DUMMY_XHR`; tile jobs now finish and fail with a `null` request
+- `OMEZarrTileSourceClass` type export and the `OpenSeadragon.OMEZarrTileSource` module augmentation
 
 ## [0.2.0] - 2026-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- OpenSeadragon data type `ome-zarr` (see `OMEZarrTileData`) with converters to `context2d` and for copying
+- Options `color`, `colorLUT`, `colorMap`, `contrastLimits` and `inverted` to override the channel rendering settings from the omero metadata
+- Option `autoBoost` to boost the brightness of dark tiles (ome-zarr.js `renderChunks` autoBoost)
+
 ### Changed
 
 - Require OpenSeadragon 6 or newer (peer dependency `>=6.0.0 <7.0.0`)
 - Updated OpenSeadragon to 6.1.1
 - Updated ome-zarr.js to 0.0.20 and zarrita to 0.7.5
-- Switched from the deprecated `renderImage` function to the `NgffImage.renderArray` API
-- Tiles are passed to OpenSeadragon as 2D canvas contexts instead of PNG images, skipping the PNG encode/decode per tile
+- Switched from the deprecated `renderImage` function to `NgffImage` for loading and `getSlices`/`renderChunks` for rendering
+- Tiles are downloaded as raw single-channel zarrita chunks (OpenSeadragon data type `ome-zarr`) and rendered to `context2d` by a registered converter, so tiles can be re-rendered from cache without re-downloading
+- Multi-channel images require the `c` option
 - Aborted tile downloads now also cancel the underlying chunk requests
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Require OpenSeadragon 6 or newer (peer dependency `>=6.0.0 <7.0.0`)
 - Updated OpenSeadragon to 6.1.1
+- Updated ome-zarr.js to 0.0.20 and zarrita to 0.7.5
+- Switched from the deprecated `renderImage` function to the `NgffImage.render` API
+- Aborted tile downloads now also cancel the underlying chunk requests
+
+### Fixed
+
+- The `c` option now selects the channel to render (previously ignored)
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -38,10 +38,16 @@ OMEZarrTileSource.enable(OpenSeadragon);
 const tileSource2 = {
     type: "ome-zarr",
     url: url,
+    // c: undefined,  // required for multi-channel images
+    // z: undefined,  // undefined = omero metadata default
+    // t: undefined,  // undefined = omero metadata default
     // zip: undefined,  // undefined = OME-Zarr ZIP auto-detection based on .ozx suffix
-    // t: undefined,
-    // c: undefined,
-    // z: undefined
+    // color: undefined,  // undefined = omero metadata
+    // colorLUT: undefined,  // undefined = omero metadata; takes precedence over colorMap
+    // colorMap: undefined,  // undefined = omero metadata
+    // contrastLimits: undefined,  // [ start, end ]; undefined = omero metadata
+    // inverted: undefined,  // undefined = omero metadata; ignored with colorMap
+    // autoBoost: undefined  // boost brightness of dark tiles (default false)
 };
 
 // direct instantiation with URL (works with any OME-Zarr storage backend)
@@ -50,10 +56,16 @@ const tileSource3 = new OMEZarrTileSource(url);
 // direct instantiation with options object (no prior enabling required)
 const tileSource4 = new OMEZarrTileSource({
     url: url,
+    // c: undefined,  // required for multi-channel images
+    // z: undefined,  // undefined = omero metadata default
+    // t: undefined,  // undefined = omero metadata default
     // zip: undefined,  // undefined = OME-Zarr ZIP auto-detection based on .ozx suffix
-    // t: undefined,
-    // c: undefined,
-    // z: undefined
+    // color: undefined,  // undefined = omero metadata
+    // colorLUT: undefined,  // undefined = omero metadata; takes precedence over colorMap
+    // colorMap: undefined,  // undefined = omero metadata
+    // contrastLimits: undefined,  // [ start, end ]; undefined = omero metadata
+    // inverted: undefined,  // undefined = omero metadata; ignored with colorMap
+    // autoBoost: undefined  // boost brightness of dark tiles (default false)
 });
 
 const viewer = OpenSeadragon(
@@ -66,6 +78,19 @@ const viewer = OpenSeadragon(
     ]
 );
 ```
+
+## Data pipeline
+
+Tiles are downloaded as raw single-channel zarrita chunks and passed to
+OpenSeadragon with the data type `ome-zarr` (see the `OMEZarrTileData` type).
+Multi-channel images therefore require the `c` option. A converter from
+`ome-zarr` to `context2d` is registered on `OpenSeadragon.converter` when the
+module is imported (and by `OMEZarrTileSource.enable`). It reads the rendering
+settings (color, color LUT/map, contrast limits, inversion) at conversion time
+from the omero channel referenced by the tile data (`OMEZarrTileData.channel`).
+The channel object is shared by all tiles of a tile source, so advanced users
+may modify it (e.g. from a `tile-invalidated` handler) and re-render the
+cached tiles using `viewer.requestInvalidate()`.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ An OpenSeadragon tile source for the OME-Zarr bioimage file format
 
 ## Prerequisites
 
-OpenSeadragon 5 or newer
+OpenSeadragon 6 or newer
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -38,15 +38,11 @@ OMEZarrTileSource.enable(OpenSeadragon);
 const tileSource2 = {
     type: "ome-zarr",
     url: url,
-    // c: undefined,  // required for multi-channel images
+    // zip: undefined,  // undefined = OME-Zarr ZIP auto-detection based on .ozx suffix
+    // c: undefined,  // undefined = composite of all active channels (requires dataType "context2d")
     // z: undefined,  // undefined = omero metadata default
     // t: undefined,  // undefined = omero metadata default
-    // zip: undefined,  // undefined = OME-Zarr ZIP auto-detection based on .ozx suffix
-    // color: undefined,  // undefined = omero metadata
-    // colorLUT: undefined,  // undefined = omero metadata; takes precedence over colorMap
-    // colorMap: undefined,  // undefined = omero metadata
-    // contrastLimits: undefined,  // [ start, end ]; undefined = omero metadata
-    // inverted: undefined,  // undefined = omero metadata; ignored with colorMap
+    // dataType: undefined,  // "context2d" (default, rendered tiles) or "ome-zarr" (raw single-channel chunks)
     // autoBoost: undefined  // boost brightness of dark tiles (default false)
 };
 
@@ -56,15 +52,11 @@ const tileSource3 = new OMEZarrTileSource(url);
 // direct instantiation with options object (no prior enabling required)
 const tileSource4 = new OMEZarrTileSource({
     url: url,
-    // c: undefined,  // required for multi-channel images
+    // zip: undefined,  // undefined = OME-Zarr ZIP auto-detection based on .ozx suffix
+    // c: undefined,  // undefined = composite of all active channels (requires dataType "context2d")
     // z: undefined,  // undefined = omero metadata default
     // t: undefined,  // undefined = omero metadata default
-    // zip: undefined,  // undefined = OME-Zarr ZIP auto-detection based on .ozx suffix
-    // color: undefined,  // undefined = omero metadata
-    // colorLUT: undefined,  // undefined = omero metadata; takes precedence over colorMap
-    // colorMap: undefined,  // undefined = omero metadata
-    // contrastLimits: undefined,  // [ start, end ]; undefined = omero metadata
-    // inverted: undefined,  // undefined = omero metadata; ignored with colorMap
+    // dataType: undefined,  // "context2d" (default, rendered tiles) or "ome-zarr" (raw single-channel chunks)
     // autoBoost: undefined  // boost brightness of dark tiles (default false)
 });
 
@@ -81,16 +73,22 @@ const viewer = OpenSeadragon(
 
 ## Data pipeline
 
-Tiles are downloaded as raw single-channel zarrita chunks and passed to
-OpenSeadragon with the data type `ome-zarr` (see the `OMEZarrTileData` type).
-Multi-channel images therefore require the `c` option. A converter from
-`ome-zarr` to `context2d` is registered on `OpenSeadragon.converter` when the
-module is imported (and by `OMEZarrTileSource.enable`). It reads the rendering
-settings (color, color LUT/map, contrast limits, inversion) at conversion time
+By default (`dataType: "context2d"`), tiles are rendered by the tile source and
+passed to OpenSeadragon as 2D canvas contexts, using the rendering settings
+(color, color LUT/map, contrast limits, inversion) from the omero metadata. For
+multi-channel images without `c`, all active channels are rendered into a
+composite image.
+
+With `dataType: "ome-zarr"`, tiles are instead downloaded as raw single-channel
+zarrita chunks and passed to OpenSeadragon with the data type `ome-zarr` (see
+the `OMEZarrTileData` type). Multi-channel images therefore require the `c`
+option. A converter from `ome-zarr` to `context2d` is registered on
+`OpenSeadragon.converter` when the module is imported (and by
+`OMEZarrTileSource.enable`). It reads the rendering settings at conversion time
 from the omero channel referenced by the tile data (`OMEZarrTileData.channel`).
 The channel object is shared by all tiles of a tile source, so advanced users
-may modify it (e.g. from a `tile-invalidated` handler) and re-render the
-cached tiles using `viewer.requestInvalidate()`.
+may modify it (e.g. from a `tile-invalidated` handler) and re-render the cached
+tiles using `viewer.requestInvalidate()`.
 
 ## Example
 

--- a/index.html
+++ b/index.html
@@ -22,8 +22,6 @@
         tileSources: {
           type: "ome-zarr",
           url: "https://livingobjects.ebi.ac.uk/idr/zarr/v0.5/idr0062A/6001240_labels.zarr",
-          c: 0,
-          z: 128,
         },
         prefixUrl: "https://openseadragon.github.io/openseadragon/images/",
         timeout: 60000, // increase timeout for large images,

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
         tileSources: {
           type: "ome-zarr",
           url: "https://livingobjects.ebi.ac.uk/idr/zarr/v0.5/idr0062A/6001240_labels.zarr",
+          c: 0,
           z: 128,
         },
         prefixUrl: "https://openseadragon.github.io/openseadragon/images/",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "zarrita": "0.5.4"
   },
   "peerDependencies": {
-    "openseadragon": ">=5.0.1 <7.0.0"
+    "openseadragon": ">=6.0.0 <7.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
@@ -54,7 +54,7 @@
     "eslint-config-prettier": "^10.1.8",
     "husky": "^9.1.7",
     "lint-staged": "^17.0.5",
-    "openseadragon": ">=5.0.1 <7.0.0",
+    "openseadragon": "^6.1.1",
     "prettier": "^3.8.3",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.4",

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
   },
   "dependencies": {
     "@zarrita/storage": "0.2.0",
-    "ome-zarr.js": "0.0.19",
-    "zarrita": "0.5.4"
+    "ome-zarr.js": "0.0.20",
+    "zarrita": "0.7.5"
   },
   "peerDependencies": {
     "openseadragon": ">=6.0.0 <7.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omezarr-tilesource",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "An OpenSeadragon tile source for the OME-Zarr bioimage file format",
   "homepage": "https://github.com/TissUUmaps/OMEZarrTileSource#readme",
   "bugs": "https://github.com/TissUUmaps/OMEZarrTileSource/issues",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,11 +11,11 @@ importers:
         specifier: 0.2.0
         version: 0.2.0
       ome-zarr.js:
-        specifier: 0.0.19
-        version: 0.0.19
+        specifier: 0.0.20
+        version: 0.0.20
       zarrita:
-        specifier: 0.5.4
-        version: 0.5.4
+        specifier: 0.7.5
+        version: 0.7.5
     devDependencies:
       "@eslint/js":
         specifier: ^10.0.1
@@ -777,12 +777,6 @@ packages:
     resolution:
       {
         integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==,
-      }
-
-  "@zarrita/storage@0.1.4":
-    resolution:
-      {
-        integrity: sha512-qURfJAQcQGRfDQ4J9HaCjGaj3jlJKc66bnRk6G/IeLUsM7WKyG7Bzsuf1EZurSXyc0I4LVcu6HaeQQ4d3kZ16g==,
       }
 
   "@zarrita/storage@0.2.0":
@@ -2154,10 +2148,10 @@ packages:
         integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==,
       }
 
-  ome-zarr.js@0.0.19:
+  ome-zarr.js@0.0.20:
     resolution:
       {
-        integrity: sha512-z+pP9AlUMvkfHBQ24F9KsjRgIDq9taeC23///ZQA/gzWOjlgbkcJlraJhjljESQC9fYYs+FiWkPsp7TAcS77ag==,
+        integrity: sha512-CvKZykEKILCXjtBYFwTiddw6eS2l2T1CA3nHH1QLure/HbBBD6e2uN/nJSMNP9m661EWWHNPKr8ggaDBxLDvzw==,
       }
 
   onetime@7.0.0:
@@ -2836,13 +2830,6 @@ packages:
       }
     engines: { node: ">=18.12.0" }
 
-  unzipit@1.4.3:
-    resolution:
-      {
-        integrity: sha512-gsq2PdJIWWGhx5kcdWStvNWit9FVdTewm4SEG7gFskWs+XCVaULt9+BwuoBtJiRE8eo3L1IPAOrbByNLtLtIlg==,
-      }
-    engines: { node: ">=12" }
-
   unzipit@2.0.0:
     resolution:
       {
@@ -2873,12 +2860,6 @@ packages:
     resolution:
       {
         integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==,
-      }
-
-  uzip-module@1.0.3:
-    resolution:
-      {
-        integrity: sha512-AMqwWZaknLM77G+VPYNZLEruMGWGzyigPK3/Whg99B3S6vGHuqsyl5ZrOv1UUF3paGK1U6PM0cnayioaryg/fA==,
       }
 
   vite-plugin-node-polyfills@0.28.0:
@@ -3063,10 +3044,10 @@ packages:
       }
     engines: { node: ">=10" }
 
-  zarrita@0.5.4:
+  zarrita@0.7.5:
     resolution:
       {
-        integrity: sha512-i88iN2+HqIQ+uiCEWLfhjbYNXAJD7IrM4h3lFwFclfqEOOhxp10amRWtqmgN5jbuy3+h0LwdyLVVzk4y9rTLgg==,
+        integrity: sha512-ZriOSEne+Wf2iuM0yjDZvUKpHNlug3dO7qJ6mAxXoOgsYV18DPOkAkwB9e0rf21bHcKcOffFuwoZwn5g6pvUeA==,
       }
 
 snapshots:
@@ -3537,11 +3518,6 @@ snapshots:
       "@volar/language-core": 2.4.28
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
-
-  "@zarrita/storage@0.1.4":
-    dependencies:
-      reference-spec-reader: 0.2.0
-      unzipit: 1.4.3
 
   "@zarrita/storage@0.2.0":
     dependencies:
@@ -4369,9 +4345,9 @@ snapshots:
 
   obug@2.1.1: {}
 
-  ome-zarr.js@0.0.19:
+  ome-zarr.js@0.0.20:
     dependencies:
-      zarrita: 0.5.4
+      zarrita: 0.7.5
 
   onetime@7.0.0:
     dependencies:
@@ -4779,10 +4755,6 @@ snapshots:
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
-  unzipit@1.4.3:
-    dependencies:
-      uzip-module: 1.0.3
-
   unzipit@2.0.0: {}
 
   uri-js@4.4.1:
@@ -4803,8 +4775,6 @@ snapshots:
       is-generator-function: 1.1.2
       is-typed-array: 1.1.15
       which-typed-array: 1.1.20
-
-  uzip-module@1.0.3: {}
 
   vite-plugin-node-polyfills@0.28.0(vite@8.0.14(yaml@2.9.0)):
     dependencies:
@@ -4898,7 +4868,7 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zarrita@0.5.4:
+  zarrita@0.7.5:
     dependencies:
-      "@zarrita/storage": 0.1.4
+      "@zarrita/storage": 0.2.0
       numcodecs: 0.3.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^17.0.5
         version: 17.0.5
       openseadragon:
-        specifier: ">=5.0.1 <7.0.0"
-        version: 6.0.2
+        specifier: ^6.1.1
+        version: 6.1.1
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
@@ -2167,10 +2167,10 @@ packages:
       }
     engines: { node: ">=18" }
 
-  openseadragon@6.0.2:
+  openseadragon@6.1.1:
     resolution:
       {
-        integrity: sha512-WNPPQWp9sHunyzkV9J2yhfxnSfDF9CfBsE6unmkdxh1uTWzFcueMvBPhmuZdY7M1v/ffJ3NdaF3Qq3jogphIbA==,
+        integrity: sha512-g4iKe2q8B642SaBT3+x4ZF3/8b1TxPPydyjmtrOLgDrlYWMKd9ZXM+1Cb/xa9DVySkvs/7l6HR1nHKfD5F3Tsw==,
       }
 
   optionator@0.9.4:
@@ -4377,7 +4377,7 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
-  openseadragon@6.0.2: {}
+  openseadragon@6.1.1: {}
 
   optionator@0.9.4:
     dependencies:

--- a/src/OMEZarrTileSource.ts
+++ b/src/OMEZarrTileSource.ts
@@ -3,10 +3,6 @@ import { NgffImage } from "ome-zarr.js";
 import OpenSeadragon from "openseadragon";
 import type * as zarr from "zarrita";
 
-type UserData = {
-  abortController?: AbortController;
-};
-
 export interface OMEZarrTileSourceOptions {
   type?: "ome-zarr";
   url: string; // TileSource.url
@@ -200,7 +196,7 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
   }
 
   downloadTileStart(context: OpenSeadragon.ImageJob): void {
-    const userData = context.userData as UserData;
+    const userData = context.userData as { abortController?: AbortController };
     const abortController = new AbortController();
     userData.abortController = abortController;
     const urlSearchParams = new URLSearchParams(context.src);
@@ -259,7 +255,7 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
   }
 
   downloadTileAbort(context: OpenSeadragon.ImageJob): void {
-    const userData = context.userData as UserData;
+    const userData = context.userData as { abortController?: AbortController };
     if (userData.abortController !== undefined) {
       userData.abortController.abort();
       userData.abortController = undefined;

--- a/src/OMEZarrTileSource.ts
+++ b/src/OMEZarrTileSource.ts
@@ -1,5 +1,5 @@
 import { ZipFileStore } from "@zarrita/storage";
-import { type Channel, NgffImage } from "ome-zarr.js";
+import { NgffImage } from "ome-zarr.js";
 import OpenSeadragon from "openseadragon";
 import * as zarr from "zarrita";
 
@@ -113,6 +113,17 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
           image.paths.map((path) => image.openArray(path)),
         );
         console.debug(`opened ${arrays.length} arrays for ${url}`);
+        if (this.c !== undefined) {
+          image.checkChannelIndex(this.c).channels.forEach((_, i) => {
+            image.setChannelActive(i, i === this.c);
+          });
+        }
+        if (this.z !== undefined) {
+          image.setZIndex(this.z);
+        }
+        if (this.t !== undefined) {
+          image.setTIndex(this.t);
+        }
         const width = arrays[0]!.shape[axisNames.indexOf("x")]!;
         const height = arrays[0]!.shape[axisNames.indexOf("y")]!;
         this._image = image;
@@ -223,13 +234,7 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
           slices: {
             x: [x * tileWidth, Math.min((x + 1) * tileWidth, maxTileWidth)],
             y: [y * tileHeight, Math.min((y + 1) * tileHeight, maxTileHeight)],
-            z: this.z,
-            t: this.t,
           },
-          channels:
-            this.c !== undefined
-              ? OMEZarrTileSource._getChannels(this._image, this.c)
-              : undefined,
           signal: abortController.signal,
         })
         .then(({ data, width, height }) => {
@@ -281,15 +286,5 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
 
   static enable(os: typeof OpenSeadragon = OpenSeadragon): void {
     os.OMEZarrTileSource = OMEZarrTileSource;
-  }
-
-  private static _getChannels(image: NgffImage, c: number): Channel[] {
-    const channels = image.omero?.channels ?? [];
-    if (c < 0 || c >= channels.length) {
-      throw new Error(
-        `channel index ${c} out of bounds for ${channels.length} channels`,
-      );
-    }
-    return channels.map((channel, i) => ({ ...channel, active: i === c }));
   }
 }

--- a/src/OMEZarrTileSource.ts
+++ b/src/OMEZarrTileSource.ts
@@ -1,5 +1,5 @@
 import { ZipFileStore } from "@zarrita/storage";
-import { type Multiscale, type Omero, renderImage } from "ome-zarr.js";
+import { type Axis, type Channel, NgffImage } from "ome-zarr.js";
 import OpenSeadragon from "openseadragon";
 import * as zarr from "zarrita";
 
@@ -38,8 +38,7 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
   readonly t?: number;
   readonly c?: number;
   readonly z?: number;
-  private _omero?: Omero;
-  private _multiscale?: Multiscale;
+  private _image?: NgffImage;
   private _axisIndices?: {
     t?: number;
     c?: number;
@@ -112,22 +111,17 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
       this.zip || (this.zip === undefined && url.endsWith(".ozx"))
         ? ZipFileStore.fromUrl(url)
         : new zarr.FetchStore(url);
-    zarr
-      .open(store, { kind: "group" })
-      .then(async (group) => {
-        console.debug(`opened group for ${url}`);
-        const { multiscale, omero } = OMEZarrTileSource._getMultiscale(group);
-        const axisIndices = OMEZarrTileSource._getAxisIndices(multiscale);
+    NgffImage.load(store)
+      .then(async (image) => {
+        console.debug(`loaded image for ${url}`);
+        const axisIndices = OMEZarrTileSource._getAxisIndices(image.axes);
         const arrays = await Promise.all(
-          multiscale.datasets.map((dataset) =>
-            zarr.open(group.resolve(dataset.path), { kind: "array" }),
-          ),
+          image.paths.map((path) => image.openArray(path)),
         );
         console.debug(`opened ${arrays.length} arrays for ${url}`);
         const maxWidth = arrays[0]!.shape[axisIndices.x]!;
         const maxHeight = arrays[0]!.shape[axisIndices.y]!;
-        this._omero = omero;
-        this._multiscale = multiscale;
+        this._image = image;
         this._axisIndices = axisIndices;
         this._arrays = arrays;
         this.width = maxWidth;
@@ -140,8 +134,7 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
         this.raiseEvent("ready", { tileSource: this });
       })
       .catch((reason) => {
-        this._omero = undefined;
-        this._multiscale = undefined;
+        this._image = undefined;
         this._axisIndices = undefined;
         this._arrays = undefined;
         this.width = 10;
@@ -226,7 +219,7 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
     const y = +urlSearchParams.get("y")!;
     try {
       if (
-        this._multiscale === undefined ||
+        this._image === undefined ||
         this._axisIndices === undefined ||
         this._arrays === undefined
       ) {
@@ -240,13 +233,21 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
       const array = this._arrays[this.maxLevel - level]!;
       const maxTileWidth = array.shape[this._axisIndices.x]!;
       const maxTileHeight = array.shape[this._axisIndices.y]!;
-      renderImage(array, this._multiscale.axes, this._omero, {
-        x: [x * tileWidth, Math.min((x + 1) * tileWidth, maxTileWidth)],
-        y: [y * tileHeight, Math.min((y + 1) * tileHeight, maxTileHeight)],
-        z: this.z,
-        c: this.c,
-        t: this.t,
-      }) // TODO https://github.com/BioNGFF/ome-zarr.js/pull/26
+      this._image
+        .render({
+          arr: array,
+          slices: {
+            x: [x * tileWidth, Math.min((x + 1) * tileWidth, maxTileWidth)],
+            y: [y * tileHeight, Math.min((y + 1) * tileHeight, maxTileHeight)],
+            z: this.z,
+            t: this.t,
+          },
+          channels:
+            this.c !== undefined
+              ? OMEZarrTileSource._getChannels(this._image, this.c)
+              : undefined,
+          signal: abortController.signal,
+        })
         .then(async (dataUrl) => {
           abortController.signal.throwIfAborted();
           console.debug(`rendered tile for level=${level}, x=${x}, y=${y}`);
@@ -304,27 +305,17 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
     os.OMEZarrTileSource = OMEZarrTileSource;
   }
 
-  // TODO https://github.com/BioNGFF/ome-zarr.js/pull/27
-  private static _getMultiscale<T extends zarr.Readable>(
-    group: zarr.Group<T>,
-  ): { multiscale: Multiscale; omero?: Omero } {
-    let metadata = group.attrs as Record<string, unknown>;
-    if ("ome" in metadata) {
-      metadata = metadata["ome"] as Record<string, unknown>;
+  private static _getChannels(image: NgffImage, c: number): Channel[] {
+    const channels = image.omero?.channels ?? [];
+    if (c < 0 || c >= channels.length) {
+      throw new Error(
+        `channel index ${c} out of bounds for ${channels.length} channels`,
+      );
     }
-    if (!("multiscales" in metadata)) {
-      throw new Error("missing OME-Zarr multiscales metadata");
-    }
-    const multiscales = metadata["multiscales"] as Multiscale[];
-    if (multiscales.length === 0) {
-      throw new Error("empty OME-Zarr multiscales metadata");
-    }
-    const multiscale = multiscales[0]!;
-    const omero = metadata["omero"] as Omero | undefined;
-    return { multiscale, omero };
+    return channels.map((channel, i) => ({ ...channel, active: i === c }));
   }
 
-  private static _getAxisIndices(multiscale: Multiscale): {
+  private static _getAxisIndices(axes: Axis[]): {
     t?: number;
     c?: number;
     z?: number;
@@ -336,8 +327,8 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
     let z: number | undefined = undefined;
     let y: number | undefined = undefined;
     let x: number | undefined = undefined;
-    for (let i = 0; i < multiscale.axes.length; i++) {
-      const axis = multiscale.axes[i]!;
+    for (let i = 0; i < axes.length; i++) {
+      const axis = axes[i]!;
       switch (axis.name) {
         case "t":
           t = i;

--- a/src/OMEZarrTileSource.ts
+++ b/src/OMEZarrTileSource.ts
@@ -10,7 +10,6 @@ declare module "openseadragon" {
 
 type UserData = {
   abortController?: AbortController;
-  img?: HTMLImageElement;
 };
 
 export interface OMEZarrTileSourceOptions {
@@ -234,7 +233,7 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
       const maxTileWidth = array.shape[this._axisIndices.x]!;
       const maxTileHeight = array.shape[this._axisIndices.y]!;
       this._image
-        .render({
+        .renderArray({
           arr: array,
           slices: {
             x: [x * tileWidth, Math.min((x + 1) * tileWidth, maxTileWidth)],
@@ -248,28 +247,26 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
               : undefined,
           signal: abortController.signal,
         })
-        .then(async (dataUrl) => {
+        .then(({ data, width, height }) => {
           abortController.signal.throwIfAborted();
           console.debug(`rendered tile for level=${level}, x=${x}, y=${y}`);
-          const img = await new Promise<HTMLImageElement>((resolve, reject) => {
-            const img = new Image();
-            userData.img = img;
-            img.onload = () => resolve(img);
-            img.onerror = (reason) => reject(new Error(reason as string));
-            img.onabort = () => {
-              if (!abortController.signal.aborted) {
-                abortController.abort();
-              }
-              const reason = abortController.signal.reason as unknown;
-              reject(
-                reason instanceof Error ? reason : new Error(String(reason)),
-              );
-            };
-            img.src = dataUrl;
-          });
-          abortController.signal.throwIfAborted();
-          console.debug(`loaded tile for level=${level}, x=${x}, y=${y}`);
-          context.finish(img, OMEZarrTileSource.DUMMY_XHR, "image");
+          const canvas = document.createElement("canvas");
+          canvas.width = width;
+          canvas.height = height;
+          const ctx = canvas.getContext("2d");
+          if (ctx === null) {
+            throw new Error("failed to get 2D canvas context");
+          }
+          ctx.putImageData(
+            new ImageData(
+              data as Uint8ClampedArray<ArrayBuffer>,
+              width,
+              height,
+            ),
+            0,
+            0,
+          );
+          context.finish(ctx, OMEZarrTileSource.DUMMY_XHR, "context2d");
         })
         .catch((reason) => {
           if (abortController.signal.aborted) {
@@ -294,10 +291,6 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
     if (userData.abortController !== undefined) {
       userData.abortController.abort();
       userData.abortController = undefined;
-    }
-    if (userData.img !== undefined) {
-      userData.img.src = "";
-      userData.img = undefined;
     }
   }
 

--- a/src/OMEZarrTileSource.ts
+++ b/src/OMEZarrTileSource.ts
@@ -141,8 +141,8 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
     if (level < 0 || level > this.maxLevel) {
       throw new Error("level out of bounds");
     }
-    const levelArray = this._arrays[this.maxLevel - level]!;
-    return levelArray.chunks[this._image.getAxesNames().indexOf("x")]!;
+    const array = this._arrays[this.maxLevel - level]!;
+    return array.chunks[this._image.getAxesNames().indexOf("x")]!;
   }
 
   getTileHeight(level: number): number {
@@ -152,8 +152,8 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
     if (level < 0 || level > this.maxLevel) {
       throw new Error("level out of bounds");
     }
-    const levelArray = this._arrays[this.maxLevel - level]!;
-    return levelArray.chunks[this._image.getAxesNames().indexOf("y")]!;
+    const array = this._arrays[this.maxLevel - level]!;
+    return array.chunks[this._image.getAxesNames().indexOf("y")]!;
   }
 
   getLevelScale(level: number): number {
@@ -163,9 +163,9 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
     if (level < 0 || level > this.maxLevel) {
       throw new Error("level out of bounds");
     }
+    const array = this._arrays[this.maxLevel - level]!;
     const xAxisIndex = this._image.getAxesNames().indexOf("x");
-    const levelArray = this._arrays[this.maxLevel - level]!;
-    const levelWidth = levelArray.shape[xAxisIndex]!;
+    const levelWidth = array.shape[xAxisIndex]!;
     const width = this._arrays[0]!.shape[xAxisIndex]!;
     return levelWidth / width;
   }

--- a/src/OMEZarrTileSource.ts
+++ b/src/OMEZarrTileSource.ts
@@ -27,8 +27,8 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
 
   // properties inherited from/required by OpenSeadragon.TileSource
   readonly url: string;
-  width: number = 10; // required starting from OpenSeadragon 6 (previously optional)
-  height: number = 10; // required starting from OpenSeadragon 6 (previously optional)
+  width: number = 10;
+  height: number = 10;
   aspectRatio: number = 1;
   dimensions: OpenSeadragon.Point = new OpenSeadragon.Point(10, 10);
   maxLevel: number = 0;

--- a/src/OMEZarrTileSource.ts
+++ b/src/OMEZarrTileSource.ts
@@ -164,10 +164,8 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
       throw new Error("level out of bounds");
     }
     const array = this._arrays[this.maxLevel - level]!;
-    const xAxisIndex = this._image.getAxesNames().indexOf("x");
-    const levelWidth = array.shape[xAxisIndex]!;
-    const width = this._arrays[0]!.shape[xAxisIndex]!;
-    return levelWidth / width;
+    const width = array.shape[this._image.getAxesNames().indexOf("x")]!;
+    return width / this.width;
   }
 
   getTileUrl(level: number, x: number, y: number): string {

--- a/src/OMEZarrTileSource.ts
+++ b/src/OMEZarrTileSource.ts
@@ -1,5 +1,5 @@
 import { ZipFileStore } from "@zarrita/storage";
-import { type Axis, type Channel, NgffImage } from "ome-zarr.js";
+import { type Channel, NgffImage } from "ome-zarr.js";
 import OpenSeadragon from "openseadragon";
 import * as zarr from "zarrita";
 
@@ -22,27 +22,16 @@ export interface OMEZarrTileSourceOptions {
 }
 
 export class OMEZarrTileSource extends OpenSeadragon.TileSource {
-  // properties inherited from/required by OpenSeadragon.TileSource
-  readonly url: string;
-  width: number = 10;
-  height: number = 10;
-  aspectRatio: number = 1;
-  dimensions: OpenSeadragon.Point = new OpenSeadragon.Point(10, 10);
-  maxLevel: number = 0;
-  ready: boolean = false;
+  declare readonly url: string;
 
   readonly zip?: boolean;
   readonly t?: number;
   readonly c?: number;
   readonly z?: number;
+
+  width: number = 10;
+  height: number = 10;
   private _image?: NgffImage;
-  private _axisIndices?: {
-    t?: number;
-    c?: number;
-    z?: number;
-    y: number;
-    x: number;
-  };
   private _arrays?: zarr.Array<zarr.DataType>[];
 
   constructor(url: string);
@@ -111,35 +100,35 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
     NgffImage.load(store)
       .then(async (image) => {
         console.debug(`loaded image for ${url}`);
-        const axisIndices = OMEZarrTileSource._getAxisIndices(image.axes);
+        const axisNames = image.getAxesNames();
+        for (const axisName of axisNames) {
+          if (!["t", "c", "z", "y", "x"].includes(axisName)) {
+            throw new Error(`unsupported axis: ${axisName}`);
+          }
+        }
+        if (!axisNames.includes("x") || !axisNames.includes("y")) {
+          throw new Error("missing X or Y axis");
+        }
         const arrays = await Promise.all(
           image.paths.map((path) => image.openArray(path)),
         );
         console.debug(`opened ${arrays.length} arrays for ${url}`);
-        const maxWidth = arrays[0]!.shape[axisIndices.x]!;
-        const maxHeight = arrays[0]!.shape[axisIndices.y]!;
+        const width = arrays[0]!.shape[axisNames.indexOf("x")]!;
+        const height = arrays[0]!.shape[axisNames.indexOf("y")]!;
         this._image = image;
-        this._axisIndices = axisIndices;
         this._arrays = arrays;
-        this.width = maxWidth;
-        this.height = maxHeight;
-        this.aspectRatio = maxWidth / maxHeight;
-        this.dimensions = new OpenSeadragon.Point(maxWidth, maxHeight);
+        this.width = width;
+        this.height = height;
         this.maxLevel = arrays.length - 1;
-        this.ready = true;
         console.debug(`ready for ${url}`);
         this.raiseEvent("ready", { tileSource: this });
       })
       .catch((reason) => {
         this._image = undefined;
-        this._axisIndices = undefined;
         this._arrays = undefined;
         this.width = 10;
         this.height = 10;
-        this.aspectRatio = 1;
-        this.dimensions = new OpenSeadragon.Point(10, 10);
         this.maxLevel = 0;
-        this.ready = false;
         const message = `failed to get image info for ${url}: ${reason}`;
         console.error(message);
         this.raiseEvent("open-failed", { message, source: url });
@@ -147,38 +136,39 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
   }
 
   getTileWidth(level: number): number {
-    if (this._axisIndices === undefined || this._arrays === undefined) {
+    if (this._image === undefined || this._arrays === undefined) {
       throw new Error("tile source not ready");
     }
     if (level < 0 || level > this.maxLevel) {
       throw new Error("level out of bounds");
     }
-    const array = this._arrays[this.maxLevel - level]!;
-    return array.chunks[this._axisIndices.x]!;
+    const levelArray = this._arrays[this.maxLevel - level]!;
+    return levelArray.chunks[this._image.getAxesNames().indexOf("x")]!;
   }
 
   getTileHeight(level: number): number {
-    if (this._axisIndices === undefined || this._arrays === undefined) {
+    if (this._image === undefined || this._arrays === undefined) {
       throw new Error("tile source not ready");
     }
     if (level < 0 || level > this.maxLevel) {
       throw new Error("level out of bounds");
     }
-    const array = this._arrays[this.maxLevel - level]!;
-    return array.chunks[this._axisIndices.y]!;
+    const levelArray = this._arrays[this.maxLevel - level]!;
+    return levelArray.chunks[this._image.getAxesNames().indexOf("y")]!;
   }
 
   getLevelScale(level: number): number {
-    if (this._axisIndices === undefined || this._arrays === undefined) {
+    if (this._image === undefined || this._arrays === undefined) {
       throw new Error("tile source not ready");
     }
     if (level < 0 || level > this.maxLevel) {
       throw new Error("level out of bounds");
     }
-    const array = this._arrays[this.maxLevel - level]!;
-    const arrayWidth = array.shape[this._axisIndices.x]!;
-    const maxWidth = this._arrays[0]!.shape[this._axisIndices.x]!;
-    return arrayWidth / maxWidth;
+    const xAxisIndex = this._image.getAxesNames().indexOf("x");
+    const levelArray = this._arrays[this.maxLevel - level]!;
+    const levelWidth = levelArray.shape[xAxisIndex]!;
+    const width = this._arrays[0]!.shape[xAxisIndex]!;
+    return levelWidth / width;
   }
 
   getTileUrl(level: number, x: number, y: number): string {
@@ -215,11 +205,7 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
     const x = +urlSearchParams.get("x")!;
     const y = +urlSearchParams.get("y")!;
     try {
-      if (
-        this._image === undefined ||
-        this._axisIndices === undefined ||
-        this._arrays === undefined
-      ) {
+      if (this._image === undefined || this._arrays === undefined) {
         throw new Error("tile source not ready");
       }
       console.debug(
@@ -227,9 +213,10 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
       );
       const tileWidth = this.getTileWidth(level);
       const tileHeight = this.getTileHeight(level);
+      const axisNames = this._image.getAxesNames();
       const array = this._arrays[this.maxLevel - level]!;
-      const maxTileWidth = array.shape[this._axisIndices.x]!;
-      const maxTileHeight = array.shape[this._axisIndices.y]!;
+      const maxTileWidth = array.shape[axisNames.indexOf("x")]!;
+      const maxTileHeight = array.shape[axisNames.indexOf("y")]!;
       this._image
         .renderArray({
           arr: array,
@@ -304,45 +291,5 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
       );
     }
     return channels.map((channel, i) => ({ ...channel, active: i === c }));
-  }
-
-  private static _getAxisIndices(axes: Axis[]): {
-    t?: number;
-    c?: number;
-    z?: number;
-    y: number;
-    x: number;
-  } {
-    let t: number | undefined = undefined;
-    let c: number | undefined = undefined;
-    let z: number | undefined = undefined;
-    let y: number | undefined = undefined;
-    let x: number | undefined = undefined;
-    for (let i = 0; i < axes.length; i++) {
-      const axis = axes[i]!;
-      switch (axis.name) {
-        case "t":
-          t = i;
-          break;
-        case "c":
-          c = i;
-          break;
-        case "z":
-          z = i;
-          break;
-        case "y":
-          y = i;
-          break;
-        case "x":
-          x = i;
-          break;
-        default:
-          throw new Error(`unsupported axis: ${axis.name}`);
-      }
-    }
-    if (x === undefined || y === undefined) {
-      throw new Error("missing X or Y axis");
-    }
-    return { t, c, z, y, x };
   }
 }

--- a/src/OMEZarrTileSource.ts
+++ b/src/OMEZarrTileSource.ts
@@ -92,14 +92,12 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
   }
 
   getImageInfo(url: string): void {
-    console.debug(`getting image info for ${url}`);
     const store =
       this.zip || (this.zip === undefined && url.endsWith(".ozx"))
         ? ZipFileStore.fromUrl(url)
         : url;
     NgffImage.load(store)
       .then(async (image) => {
-        console.debug(`loaded image for ${url}`);
         const axisNames = image.getAxesNames();
         for (const axisName of axisNames) {
           if (!["t", "c", "z", "y", "x"].includes(axisName)) {
@@ -112,7 +110,6 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
         const arrays = await Promise.all(
           image.paths.map((path) => image.openArray(path)),
         );
-        console.debug(`opened ${arrays.length} arrays for ${url}`);
         if (this.c !== undefined) {
           image.checkChannelIndex(this.c).channels.forEach((_, i) => {
             image.setChannelActive(i, i === this.c);
@@ -131,7 +128,6 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
         this.width = width;
         this.height = height;
         this.maxLevel = arrays.length - 1;
-        console.debug(`ready for ${url}`);
         this.raiseEvent("ready", { tileSource: this });
       })
       .catch((reason) => {
@@ -140,9 +136,10 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
         this.width = 10;
         this.height = 10;
         this.maxLevel = 0;
-        const message = `failed to get image info for ${url}: ${reason}`;
-        console.error(message);
-        this.raiseEvent("open-failed", { message, source: url });
+        this.raiseEvent("open-failed", {
+          message: `failed to get image info for ${url}: ${reason}`,
+          source: url,
+        });
       });
   }
 
@@ -219,9 +216,6 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
       if (this._image === undefined || this._arrays === undefined) {
         throw new Error("tile source not ready");
       }
-      console.debug(
-        `downloading tile for level=${level}, x=${x}, y=${y} from dataset ${this.maxLevel - level}`,
-      );
       const tileWidth = this.getTileWidth(level);
       const tileHeight = this.getTileHeight(level);
       this._image
@@ -235,7 +229,6 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
         })
         .then(({ data, width, height }) => {
           abortController.signal.throwIfAborted();
-          console.debug(`rendered tile for level=${level}, x=${x}, y=${y}`);
           const canvas = document.createElement("canvas");
           canvas.width = width;
           canvas.height = height;
@@ -255,20 +248,18 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
           context.finish(ctx, null, "context2d");
         })
         .catch((reason) => {
-          if (abortController.signal.aborted) {
-            console.debug(
-              `aborted tile rendering for level=${level}, x=${x}, y=${y}`,
+          if (!abortController.signal.aborted) {
+            context.fail(
+              `failed to render tile for level=${level}, x=${x}, y=${y}: ${reason}`,
+              null,
             );
-          } else {
-            const message = `failed to render tile for level=${level}, x=${x}, y=${y}: ${reason}`;
-            console.error(message);
-            context.fail(message, null);
           }
         });
     } catch (error) {
-      const message = `failed to download tile for level=${level}, x=${x}, y=${y}: ${String(error)}`;
-      console.error(message);
-      context.fail(message, null);
+      context.fail(
+        `failed to download tile for level=${level}, x=${x}, y=${y}: ${String(error)}`,
+        null,
+      );
     }
   }
 

--- a/src/OMEZarrTileSource.ts
+++ b/src/OMEZarrTileSource.ts
@@ -3,11 +3,6 @@ import { NgffImage } from "ome-zarr.js";
 import OpenSeadragon from "openseadragon";
 import type * as zarr from "zarrita";
 
-export type OMEZarrTileSourceClass = typeof OMEZarrTileSource;
-declare module "openseadragon" {
-  let OMEZarrTileSource: OMEZarrTileSourceClass;
-}
-
 type UserData = {
   abortController?: AbortController;
 };
@@ -272,6 +267,6 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
   }
 
   static enable(os: typeof OpenSeadragon = OpenSeadragon): void {
-    os.OMEZarrTileSource = OMEZarrTileSource;
+    Object.assign(os, { OMEZarrTileSource });
   }
 }

--- a/src/OMEZarrTileSource.ts
+++ b/src/OMEZarrTileSource.ts
@@ -1,29 +1,57 @@
 import { ZipFileStore } from "@zarrita/storage";
-import { NgffImage } from "ome-zarr.js";
+import {
+  type Channel,
+  NgffImage,
+  getMinMaxValues,
+  getSlices,
+  renderChunks,
+} from "ome-zarr.js";
 import OpenSeadragon from "openseadragon";
-import type * as zarr from "zarrita";
+import * as zarr from "zarrita";
 
 export interface OMEZarrTileSourceOptions {
   type?: "ome-zarr";
   url: string; // TileSource.url
-  zip?: boolean;
-  t?: number;
   c?: number;
   z?: number;
+  t?: number;
+  zip?: boolean;
+  color?: Channel["color"];
+  colorLUT?: Channel["lut"];
+  colorMap?: Channel["colorMap"];
+  contrastLimits?: [number, number];
+  inverted?: Channel["inverted"];
+  autoBoost?: boolean; // boost brightness of dark tiles (see renderChunks)
+}
+
+export interface OMEZarrTileData {
+  chunk: zarr.Chunk<zarr.NumberDataType | zarr.BigintDataType>; // (y, x) chunk
+  channel: Channel; // omero channel (required for rendering at conversion time)
+  autoBoost?: boolean; // boost brightness of dark tiles (see renderChunks)
 }
 
 export class OMEZarrTileSource extends OpenSeadragon.TileSource {
   declare readonly url: string;
 
-  readonly zip?: boolean;
-  readonly t?: number;
   readonly c?: number;
   readonly z?: number;
+  readonly t?: number;
+  readonly zip?: boolean;
+  readonly color?: Channel["color"];
+  readonly colorLUT?: Channel["lut"];
+  readonly colorMap?: Channel["colorMap"];
+  readonly contrastLimits?: [number, number];
+  readonly inverted?: Channel["inverted"];
+  readonly autoBoost?: boolean;
 
   width: number = 10;
   height: number = 10;
   private _image?: NgffImage;
-  private _arrays?: zarr.Array<zarr.DataType>[];
+  private _arrays?: zarr.Array<zarr.NumberDataType | zarr.BigintDataType>[];
+
+  static {
+    OMEZarrTileSource._learnConverters(OpenSeadragon);
+  }
 
   constructor(url: string);
   constructor(options: OMEZarrTileSourceOptions);
@@ -34,10 +62,16 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
     } else {
       super(config.url); // invokes getImageInfo
       this.url = config.url;
-      this.zip = config.zip;
-      this.t = config.t;
       this.c = config.c;
       this.z = config.z;
+      this.t = config.t;
+      this.zip = config.zip;
+      this.color = config.color;
+      this.colorLUT = config.colorLUT;
+      this.colorMap = config.colorMap;
+      this.contrastLimits = config.contrastLimits;
+      this.inverted = config.inverted;
+      this.autoBoost = config.autoBoost;
     }
   }
 
@@ -75,10 +109,17 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
     return (
       other instanceof OMEZarrTileSource &&
       this.url === other.url &&
-      this.zip === other.zip &&
-      this.t === other.t &&
       this.c === other.c &&
-      this.z === other.z
+      this.z === other.z &&
+      this.t === other.t &&
+      this.zip === other.zip &&
+      this.color === other.color &&
+      this.colorLUT === other.colorLUT && // deliberately by reference
+      this.colorMap === other.colorMap && // deliberately by reference
+      this.contrastLimits?.[0] === other.contrastLimits?.[0] &&
+      this.contrastLimits?.[1] === other.contrastLimits?.[1] &&
+      this.inverted === other.inverted &&
+      this.autoBoost === other.autoBoost
     );
   }
 
@@ -101,16 +142,35 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
         const arrays = await Promise.all(
           image.paths.map((path) => image.openArray(path)),
         );
-        if (this.c !== undefined) {
-          image.checkChannelIndex(this.c).channels.forEach((_, i) => {
-            image.setChannelActive(i, i === this.c);
-          });
+        const channelAxis = axisNames.indexOf("c");
+        const numChannels =
+          channelAxis >= 0 ? arrays[0]!.shape[channelAxis]! : 1;
+        if (this.c === undefined && numChannels > 1) {
+          throw new Error(`Image with ${numChannels} channels; specify c`);
         }
+        const channelIndex = this.c ?? 0;
+        image.checkChannelIndex(channelIndex);
         if (this.z !== undefined) {
           image.setZIndex(this.z);
         }
         if (this.t !== undefined) {
           image.setTIndex(this.t);
+        }
+        if (this.color !== undefined) {
+          image.setChannelColor(channelIndex, this.color);
+        }
+        if (this.colorLUT !== undefined) {
+          image.setChannelLut(channelIndex, this.colorLUT);
+        }
+        if (this.colorMap !== undefined) {
+          image.setChannelColorMap(channelIndex, this.colorMap);
+        }
+        if (this.contrastLimits !== undefined) {
+          image.setChannelStart(channelIndex, this.contrastLimits[0]);
+          image.setChannelEnd(channelIndex, this.contrastLimits[1]);
+        }
+        if (this.inverted !== undefined) {
+          image.setChannelInverted(channelIndex, this.inverted);
         }
         const width = arrays[0]!.shape[axisNames.indexOf("x")]!;
         const height = arrays[0]!.shape[axisNames.indexOf("y")]!;
@@ -121,14 +181,14 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
         this.maxLevel = arrays.length - 1;
         this.raiseEvent("ready", { tileSource: this });
       })
-      .catch((reason) => {
+      .catch((error) => {
         this._image = undefined;
         this._arrays = undefined;
         this.width = 10;
         this.height = 10;
         this.maxLevel = 0;
         this.raiseEvent("open-failed", {
-          message: `failed to get image info for ${url}: ${reason}`,
+          message: `failed to get image info for ${url}: ${error}`,
           source: url,
         });
       });
@@ -181,14 +241,41 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
     url.searchParams.append("level", level.toString());
     url.searchParams.append("x", x.toString());
     url.searchParams.append("y", y.toString());
-    if (this.z !== undefined) {
-      url.searchParams.append("z", this.z.toString());
-    }
     if (this.c !== undefined) {
       url.searchParams.append("c", this.c.toString());
     }
+    if (this.z !== undefined) {
+      url.searchParams.append("z", this.z.toString());
+    }
     if (this.t !== undefined) {
       url.searchParams.append("t", this.t.toString());
+    }
+    if (this.zip !== undefined) {
+      url.searchParams.append("zip", this.zip.toString());
+    }
+    if (this.color !== undefined) {
+      url.searchParams.append("color", this.color);
+    }
+    if (this.colorLUT !== undefined) {
+      url.searchParams.append("lut", OMEZarrTileSource._digest(this.colorLUT));
+    }
+    if (this.colorMap !== undefined) {
+      url.searchParams.append(
+        "colorMap",
+        OMEZarrTileSource._digest([...this.colorMap]),
+      );
+    }
+    if (this.contrastLimits !== undefined) {
+      url.searchParams.append(
+        "contrastLimits",
+        `${this.contrastLimits[0]},${this.contrastLimits[1]}`,
+      );
+    }
+    if (this.inverted !== undefined) {
+      url.searchParams.append("inverted", this.inverted.toString());
+    }
+    if (this.autoBoost !== undefined) {
+      url.searchParams.append("autoBoost", this.autoBoost.toString());
     }
     return url.toString();
   }
@@ -205,45 +292,40 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
       if (this._image === undefined || this._arrays === undefined) {
         throw new Error("tile source not ready");
       }
+      const array = this._arrays[this.maxLevel - level]!;
+      const omero = this._image.checkChannelIndex(this.c ?? 0);
       const tileWidth = this.getTileWidth(level);
       const tileHeight = this.getTileHeight(level);
-      this._image
-        .renderArray({
-          arr: this._arrays[this.maxLevel - level]!,
-          slices: {
-            x: [x * tileWidth, (x + 1) * tileWidth],
-            y: [y * tileHeight, (y + 1) * tileHeight],
-          },
-          signal: abortController.signal,
-        })
-        .then(({ data, width, height }) => {
-          abortController.signal.throwIfAborted();
-          const canvas = document.createElement("canvas");
-          canvas.width = width;
-          canvas.height = height;
-          const ctx = canvas.getContext("2d");
-          if (ctx === null) {
-            throw new Error("failed to get 2D canvas context");
-          }
-          ctx.putImageData(
-            new ImageData(
-              data as Uint8ClampedArray<ArrayBuffer>,
-              width,
-              height,
-            ),
-            0,
-            0,
-          );
-          context.finish(ctx, null, "context2d");
-        })
-        .catch((reason) => {
+      const selection = getSlices(
+        [this.c ?? 0],
+        array.shape,
+        this._image.getAxesNames(),
+        {
+          x: [x * tileWidth, (x + 1) * tileWidth], // clamped by zarrita
+          y: [y * tileHeight, (y + 1) * tileHeight], // clamped by zarrita
+          z: omero.rdefs.defaultZ,
+          t: omero.rdefs.defaultT,
+        },
+      )[0] as (number | zarr.Slice | null)[];
+      zarr.get(array, selection, { signal: abortController.signal }).then(
+        (chunk) => {
+          // no abort check needed: finish() is a no-op after abort()
+          const data: OMEZarrTileData = {
+            chunk,
+            channel: omero.channels[this.c ?? 0]!,
+            autoBoost: this.autoBoost,
+          };
+          context.finish(data, null, "ome-zarr");
+        },
+        (error) => {
           if (!abortController.signal.aborted) {
             context.fail(
-              `failed to render tile for level=${level}, x=${x}, y=${y}: ${reason}`,
+              `failed to render tile for level=${level}, x=${x}, y=${y}: ${error}`,
               null,
             );
           }
-        });
+        },
+      );
     } catch (error) {
       context.fail(
         `failed to download tile for level=${level}, x=${x}, y=${y}: ${String(error)}`,
@@ -262,5 +344,78 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
 
   static enable(os: typeof OpenSeadragon = OpenSeadragon): void {
     Object.assign(os, { OMEZarrTileSource });
+    OMEZarrTileSource._learnConverters(os);
+  }
+
+  private static _learnConverters(os: typeof OpenSeadragon): void {
+    if (os.converter.existsType("ome-zarr")) {
+      return;
+    }
+    os.converter.learn(
+      "ome-zarr",
+      "context2d",
+      (_tile, { chunk, channel, autoBoost }: OMEZarrTileData) => {
+        const hex = channel.color.replace(/^#/, "");
+        const channelColor: [number, number, number] = [
+          parseInt(hex.slice(0, 2), 16),
+          parseInt(hex.slice(2, 4), 16),
+          parseInt(hex.slice(4, 6), 16),
+        ];
+        const [vmin, vmax] =
+          channel.window.start !== undefined && channel.window.end !== undefined
+            ? [channel.window.start, channel.window.end]
+            : getMinMaxValues(chunk);
+        const channelContrastLimits: [number, number] =
+          vmin < vmax ? [vmin, vmax] : [vmin, vmin + 1];
+        const rgba = renderChunks(
+          [chunk],
+          [channelContrastLimits],
+          [channelColor],
+          [channel.lut ?? channel.colorMap],
+          [channel.inverted === true],
+          autoBoost,
+        );
+        return OMEZarrTileSource._toContext2D(
+          rgba as Uint8ClampedArray<ArrayBuffer>,
+          chunk.shape[1]!,
+          chunk.shape[0]!,
+        );
+      },
+      1,
+      1,
+    );
+    os.converter.learn(
+      "ome-zarr",
+      "ome-zarr",
+      (_tile, data: OMEZarrTileData) => ({
+        ...data,
+        chunk: { ...data.chunk, data: data.chunk.data.slice() },
+      }),
+    );
+  }
+
+  private static _toContext2D(
+    rgba: Uint8ClampedArray<ArrayBuffer>,
+    width: number,
+    height: number,
+  ): CanvasRenderingContext2D {
+    const canvas = document.createElement("canvas");
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext("2d");
+    if (ctx === null) {
+      throw new Error("failed to get 2D canvas context");
+    }
+    ctx.putImageData(new ImageData(rgba, width, height), 0, 0);
+    return ctx;
+  }
+
+  // FNV-1a hash of the JSON representation (short, stable key for large objects)
+  private static _digest(value: unknown): string {
+    let hash = 0x811c9dc5;
+    for (const char of JSON.stringify(value)) {
+      hash = Math.imul(hash ^ char.charCodeAt(0), 0x01000193) >>> 0;
+    }
+    return hash.toString(16);
   }
 }

--- a/src/OMEZarrTileSource.ts
+++ b/src/OMEZarrTileSource.ts
@@ -2,6 +2,7 @@ import { ZipFileStore } from "@zarrita/storage";
 import {
   type Channel,
   NgffImage,
+  type Omero,
   getMinMaxValues,
   getSlices,
   renderChunks,
@@ -12,15 +13,11 @@ import * as zarr from "zarrita";
 export interface OMEZarrTileSourceOptions {
   type?: "ome-zarr";
   url: string; // TileSource.url
+  zip?: boolean;
   c?: number;
   z?: number;
   t?: number;
-  zip?: boolean;
-  color?: Channel["color"];
-  colorLUT?: Channel["lut"];
-  colorMap?: Channel["colorMap"];
-  contrastLimits?: [number, number];
-  inverted?: Channel["inverted"];
+  dataType?: "ome-zarr" | "context2d"; // default: "context2d"
   autoBoost?: boolean; // boost brightness of dark tiles (see renderChunks)
 }
 
@@ -32,16 +29,11 @@ export interface OMEZarrTileData {
 
 export class OMEZarrTileSource extends OpenSeadragon.TileSource {
   declare readonly url: string;
-
+  readonly zip?: boolean;
   readonly c?: number;
   readonly z?: number;
   readonly t?: number;
-  readonly zip?: boolean;
-  readonly color?: Channel["color"];
-  readonly colorLUT?: Channel["lut"];
-  readonly colorMap?: Channel["colorMap"];
-  readonly contrastLimits?: [number, number];
-  readonly inverted?: Channel["inverted"];
+  readonly dataType: "ome-zarr" | "context2d";
   readonly autoBoost?: boolean;
 
   width: number = 10;
@@ -59,18 +51,15 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
     if (typeof config === "string") {
       super(config); // invokes getImageInfo
       this.url = config;
+      this.dataType = "context2d";
     } else {
       super(config.url); // invokes getImageInfo
       this.url = config.url;
+      this.zip = config.zip;
       this.c = config.c;
       this.z = config.z;
       this.t = config.t;
-      this.zip = config.zip;
-      this.color = config.color;
-      this.colorLUT = config.colorLUT;
-      this.colorMap = config.colorMap;
-      this.contrastLimits = config.contrastLimits;
-      this.inverted = config.inverted;
+      this.dataType = config.dataType ?? "context2d";
       this.autoBoost = config.autoBoost;
     }
   }
@@ -109,26 +98,21 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
     return (
       other instanceof OMEZarrTileSource &&
       this.url === other.url &&
+      this.zip === other.zip &&
       this.c === other.c &&
       this.z === other.z &&
       this.t === other.t &&
-      this.zip === other.zip &&
-      this.color === other.color &&
-      this.colorLUT === other.colorLUT && // deliberately by reference
-      this.colorMap === other.colorMap && // deliberately by reference
-      this.contrastLimits?.[0] === other.contrastLimits?.[0] &&
-      this.contrastLimits?.[1] === other.contrastLimits?.[1] &&
-      this.inverted === other.inverted &&
+      this.dataType === other.dataType &&
       this.autoBoost === other.autoBoost
     );
   }
 
   getImageInfo(url: string): void {
-    const store =
+    NgffImage.load(
       this.zip || (this.zip === undefined && url.endsWith(".ozx"))
         ? ZipFileStore.fromUrl(url)
-        : url;
-    NgffImage.load(store)
+        : url,
+    )
       .then(async (image) => {
         const axisNames = image.getAxesNames();
         for (const axisName of axisNames) {
@@ -139,45 +123,45 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
         if (!axisNames.includes("x") || !axisNames.includes("y")) {
           throw new Error("missing X or Y axis");
         }
+        if (axisNames.indexOf("y") > axisNames.indexOf("x")) {
+          throw new Error("X axis must come after Y axis");
+        }
         const arrays = await Promise.all(
           image.paths.map((path) => image.openArray(path)),
         );
         const channelAxis = axisNames.indexOf("c");
         const numChannels =
           channelAxis >= 0 ? arrays[0]!.shape[channelAxis]! : 1;
-        if (this.c === undefined && numChannels > 1) {
-          throw new Error(`Image with ${numChannels} channels; specify c`);
-        }
-        const channelIndex = this.c ?? 0;
-        image.checkChannelIndex(channelIndex);
         if (this.z !== undefined) {
           image.setZIndex(this.z);
         }
         if (this.t !== undefined) {
           image.setTIndex(this.t);
         }
-        if (this.color !== undefined) {
-          image.setChannelColor(channelIndex, this.color);
+        if (
+          this.dataType !== "context2d" &&
+          this.c === undefined &&
+          numChannels > 1
+        ) {
+          throw new Error(
+            `Multi-channel image with ${numChannels} channels; specify c or render as "context2d"`,
+          );
         }
-        if (this.colorLUT !== undefined) {
-          image.setChannelLut(channelIndex, this.colorLUT);
+        const omero = image.checkChannelIndex(this.c ?? 0);
+        if (omero.channels.length !== numChannels) {
+          throw new Error(
+            `OME-Zarr metadata lists ${omero.channels.length} channels, but the image has ${numChannels}`,
+          );
         }
-        if (this.colorMap !== undefined) {
-          image.setChannelColorMap(channelIndex, this.colorMap);
+        if (this._getActiveChannelIndices(omero).length === 0) {
+          throw new Error(
+            "No active channels; specify c or activate channels in the OME-Zarr metadata",
+          );
         }
-        if (this.contrastLimits !== undefined) {
-          image.setChannelStart(channelIndex, this.contrastLimits[0]);
-          image.setChannelEnd(channelIndex, this.contrastLimits[1]);
-        }
-        if (this.inverted !== undefined) {
-          image.setChannelInverted(channelIndex, this.inverted);
-        }
-        const width = arrays[0]!.shape[axisNames.indexOf("x")]!;
-        const height = arrays[0]!.shape[axisNames.indexOf("y")]!;
         this._image = image;
         this._arrays = arrays;
-        this.width = width;
-        this.height = height;
+        this.width = arrays[0]!.shape[axisNames.indexOf("x")]!;
+        this.height = arrays[0]!.shape[axisNames.indexOf("y")]!;
         this.maxLevel = arrays.length - 1;
         this.raiseEvent("ready", { tileSource: this });
       })
@@ -241,6 +225,9 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
     url.searchParams.append("level", level.toString());
     url.searchParams.append("x", x.toString());
     url.searchParams.append("y", y.toString());
+    if (this.zip !== undefined) {
+      url.searchParams.append("zip", this.zip.toString());
+    }
     if (this.c !== undefined) {
       url.searchParams.append("c", this.c.toString());
     }
@@ -250,30 +237,7 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
     if (this.t !== undefined) {
       url.searchParams.append("t", this.t.toString());
     }
-    if (this.zip !== undefined) {
-      url.searchParams.append("zip", this.zip.toString());
-    }
-    if (this.color !== undefined) {
-      url.searchParams.append("color", this.color);
-    }
-    if (this.colorLUT !== undefined) {
-      url.searchParams.append("lut", OMEZarrTileSource._digest(this.colorLUT));
-    }
-    if (this.colorMap !== undefined) {
-      url.searchParams.append(
-        "colorMap",
-        OMEZarrTileSource._digest([...this.colorMap]),
-      );
-    }
-    if (this.contrastLimits !== undefined) {
-      url.searchParams.append(
-        "contrastLimits",
-        `${this.contrastLimits[0]},${this.contrastLimits[1]}`,
-      );
-    }
-    if (this.inverted !== undefined) {
-      url.searchParams.append("inverted", this.inverted.toString());
-    }
+    url.searchParams.append("dataType", this.dataType);
     if (this.autoBoost !== undefined) {
       url.searchParams.append("autoBoost", this.autoBoost.toString());
     }
@@ -294,10 +258,12 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
       }
       const array = this._arrays[this.maxLevel - level]!;
       const omero = this._image.checkChannelIndex(this.c ?? 0);
+      const activeChannelIndices = this._getActiveChannelIndices(omero);
+      const channels = activeChannelIndices.map((i) => omero.channels[i]!);
       const tileWidth = this.getTileWidth(level);
       const tileHeight = this.getTileHeight(level);
-      const selection = getSlices(
-        [this.c ?? 0],
+      const selections = getSlices(
+        activeChannelIndices,
         array.shape,
         this._image.getAxesNames(),
         {
@@ -306,19 +272,34 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
           z: omero.rdefs.defaultZ,
           t: omero.rdefs.defaultT,
         },
-      )[0] as (number | zarr.Slice | null)[];
-      zarr.get(array, selection, { signal: abortController.signal }).then(
-        (chunk) => {
+      ) as (number | zarr.Slice | null)[][];
+      Promise.all(
+        selections.map((selection) =>
+          zarr.get(array, selection, { signal: abortController.signal }),
+        ),
+      ).then(
+        (chunks) => {
           // no abort check needed: finish() is a no-op after abort()
-          const data: OMEZarrTileData = {
-            chunk,
-            channel: omero.channels[this.c ?? 0]!,
-            autoBoost: this.autoBoost,
-          };
-          context.finish(data, null, "ome-zarr");
+          if (this.dataType === "context2d") {
+            const ctx = OMEZarrTileSource._render(
+              chunks,
+              channels,
+              this.autoBoost,
+            );
+            context.finish(ctx, null, "context2d");
+          } else {
+            const data: OMEZarrTileData = {
+              chunk: chunks[0]!,
+              channel: channels[0]!,
+              autoBoost: this.autoBoost,
+            };
+            context.finish(data, null, "ome-zarr");
+          }
         },
         (error) => {
-          if (!abortController.signal.aborted) {
+          const aborted = abortController.signal.aborted;
+          abortController.abort(); // cancel the remaining channel requests
+          if (!aborted) {
             context.fail(
               `failed to render tile for level=${level}, x=${x}, y=${y}: ${error}`,
               null,
@@ -354,33 +335,8 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
     os.converter.learn(
       "ome-zarr",
       "context2d",
-      (_tile, { chunk, channel, autoBoost }: OMEZarrTileData) => {
-        const hex = channel.color.replace(/^#/, "");
-        const channelColor: [number, number, number] = [
-          parseInt(hex.slice(0, 2), 16),
-          parseInt(hex.slice(2, 4), 16),
-          parseInt(hex.slice(4, 6), 16),
-        ];
-        const [vmin, vmax] =
-          channel.window.start !== undefined && channel.window.end !== undefined
-            ? [channel.window.start, channel.window.end]
-            : getMinMaxValues(chunk);
-        const channelContrastLimits: [number, number] =
-          vmin < vmax ? [vmin, vmax] : [vmin, vmin + 1];
-        const rgba = renderChunks(
-          [chunk],
-          [channelContrastLimits],
-          [channelColor],
-          [channel.lut ?? channel.colorMap],
-          [channel.inverted === true],
-          autoBoost,
-        );
-        return OMEZarrTileSource._toContext2D(
-          rgba as Uint8ClampedArray<ArrayBuffer>,
-          chunk.shape[1]!,
-          chunk.shape[0]!,
-        );
-      },
+      (_tile, { chunk, channel, autoBoost }: OMEZarrTileData) =>
+        OMEZarrTileSource._render([chunk], [channel], autoBoost),
       1,
       1,
     );
@@ -394,11 +350,47 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
     );
   }
 
-  private static _toContext2D(
-    rgba: Uint8ClampedArray<ArrayBuffer>,
-    width: number,
-    height: number,
+  private _getActiveChannelIndices(omero: Omero): number[] {
+    if (this.c !== undefined || this.dataType !== "context2d") {
+      return [this.c ?? 0];
+    }
+    return omero.channels.flatMap((channel, i) =>
+      channel.active !== false ? [i] : [],
+    );
+  }
+
+  private static _render(
+    chunks: zarr.Chunk<zarr.NumberDataType | zarr.BigintDataType>[],
+    channels: Channel[],
+    autoBoost?: boolean,
   ): CanvasRenderingContext2D {
+    const channelColors = channels.map((channel): [number, number, number] => {
+      const hex = channel.color.replace(/^#/, "");
+      return [
+        parseInt(hex.slice(0, 2), 16),
+        parseInt(hex.slice(2, 4), 16),
+        parseInt(hex.slice(4, 6), 16),
+      ];
+    });
+    const channelContrastLimits = channels.map(
+      (channel, i): [number, number] => {
+        const [vmin, vmax] =
+          channel.window.start !== undefined && channel.window.end !== undefined
+            ? [channel.window.start, channel.window.end]
+            : getMinMaxValues(chunks[i]);
+        return vmin < vmax ? [vmin, vmax] : [vmin, vmin + 1];
+      },
+    );
+    const rgba = renderChunks(
+      chunks,
+      channelContrastLimits,
+      channelColors,
+      channels.map((channel) => channel.lut ?? channel.colorMap),
+      channels.map((channel) => channel.inverted === true),
+      autoBoost,
+    ) as Uint8ClampedArray<ArrayBuffer>;
+    const width = chunks[0]!.shape[1]!;
+    const height = chunks[0]!.shape[0]!;
     const canvas = document.createElement("canvas");
     canvas.width = width;
     canvas.height = height;
@@ -406,16 +398,8 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
     if (ctx === null) {
       throw new Error("failed to get 2D canvas context");
     }
-    ctx.putImageData(new ImageData(rgba, width, height), 0, 0);
+    const data = new ImageData(rgba, width, height);
+    ctx.putImageData(data, 0, 0);
     return ctx;
-  }
-
-  // FNV-1a hash of the JSON representation (short, stable key for large objects)
-  private static _digest(value: unknown): string {
-    let hash = 0x811c9dc5;
-    for (const char of JSON.stringify(value)) {
-      hash = Math.imul(hash ^ char.charCodeAt(0), 0x01000193) >>> 0;
-    }
-    return hash.toString(16);
   }
 }

--- a/src/OMEZarrTileSource.ts
+++ b/src/OMEZarrTileSource.ts
@@ -1,7 +1,7 @@
 import { ZipFileStore } from "@zarrita/storage";
 import { NgffImage } from "ome-zarr.js";
 import OpenSeadragon from "openseadragon";
-import * as zarr from "zarrita";
+import type * as zarr from "zarrita";
 
 export type OMEZarrTileSourceClass = typeof OMEZarrTileSource;
 declare module "openseadragon" {
@@ -96,7 +96,7 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
     const store =
       this.zip || (this.zip === undefined && url.endsWith(".ozx"))
         ? ZipFileStore.fromUrl(url)
-        : new zarr.FetchStore(url);
+        : url;
     NgffImage.load(store)
       .then(async (image) => {
         console.debug(`loaded image for ${url}`);

--- a/src/OMEZarrTileSource.ts
+++ b/src/OMEZarrTileSource.ts
@@ -22,8 +22,6 @@ export interface OMEZarrTileSourceOptions {
 }
 
 export class OMEZarrTileSource extends OpenSeadragon.TileSource {
-  static readonly DUMMY_XHR = new XMLHttpRequest();
-
   // properties inherited from/required by OpenSeadragon.TileSource
   readonly url: string;
   width: number = 10;
@@ -266,7 +264,7 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
             0,
             0,
           );
-          context.finish(ctx, OMEZarrTileSource.DUMMY_XHR, "context2d");
+          context.finish(ctx, null, "context2d");
         })
         .catch((reason) => {
           if (abortController.signal.aborted) {
@@ -276,13 +274,13 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
           } else {
             const message = `failed to render tile for level=${level}, x=${x}, y=${y}: ${reason}`;
             console.error(message);
-            context.fail(message, OMEZarrTileSource.DUMMY_XHR);
+            context.fail(message, null);
           }
         });
     } catch (error) {
       const message = `failed to download tile for level=${level}, x=${x}, y=${y}: ${String(error)}`;
       console.error(message);
-      context.fail(message, OMEZarrTileSource.DUMMY_XHR);
+      context.fail(message, null);
     }
   }
 

--- a/src/OMEZarrTileSource.ts
+++ b/src/OMEZarrTileSource.ts
@@ -224,16 +224,12 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
       );
       const tileWidth = this.getTileWidth(level);
       const tileHeight = this.getTileHeight(level);
-      const axisNames = this._image.getAxesNames();
-      const array = this._arrays[this.maxLevel - level]!;
-      const maxTileWidth = array.shape[axisNames.indexOf("x")]!;
-      const maxTileHeight = array.shape[axisNames.indexOf("y")]!;
       this._image
         .renderArray({
-          arr: array,
+          arr: this._arrays[this.maxLevel - level]!,
           slices: {
-            x: [x * tileWidth, Math.min((x + 1) * tileWidth, maxTileWidth)],
-            y: [y * tileHeight, Math.min((y + 1) * tileHeight, maxTileHeight)],
+            x: [x * tileWidth, (x + 1) * tileWidth],
+            y: [y * tileHeight, (y + 1) * tileHeight],
           },
           signal: abortController.signal,
         })

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { OMEZarrTileSource } from "./OMEZarrTileSource";
 
 export {
   OMEZarrTileSource,
+  type OMEZarrTileData,
   type OMEZarrTileSourceOptions,
 } from "./OMEZarrTileSource";
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,6 @@ import { OMEZarrTileSource } from "./OMEZarrTileSource";
 
 export {
   OMEZarrTileSource,
-  type OMEZarrTileSourceClass,
   type OMEZarrTileSourceOptions,
 } from "./OMEZarrTileSource";
 


### PR DESCRIPTION
Moves the tile source to OpenSeadragon 6's data pipeline and prepares release v0.3.0.

## Dependencies
- OpenSeadragon peer range narrowed to `>=6.0.0 <7.0.0` (dev dependency `^6.1.1`); OpenSeadragon 5 is no longer supported.
- ome-zarr.js `0.0.19 -> 0.0.20` and zarrita `0.5.4 -> 0.7.5` (ome-zarr.js 0.0.20 requires zarrita 0.7; a single zarrita copy is installed).

## Tile source
- Loading goes through `NgffImage` (handles OME-Zarr 0.4/0.5, synthesizes omero metadata if absent); all pyramid levels are opened at `ready` time so tile sizes and level scales are available synchronously.
- Tiles are fetched as raw zarrita chunks via `getSlices` + `zarr.get` (abortable; aborting cancels the underlying requests) instead of the deprecated `renderImage`. Manual x/y clamping is gone (zarrita clamps slices).
- New `dataType` option:
  - `"context2d"` (default): the tile source renders tiles with `renderChunks` and passes 2D canvas contexts. Multi-channel images without `c` are rendered as a composite of all active channels using their omero settings.
  - `"ome-zarr"`: tiles are passed as raw single-channel data (`OMEZarrTileData`: chunk + omero channel); a converter to `context2d` and a copy converter are registered on import and by `enable()`, so tiles can be re-rendered from cache. Requires `c` for multi-channel images.
- New `autoBoost` option (ome-zarr.js brightness boost for dark tiles).
- `z`/`t` default to the omero `rdefs` planes; `c` now actually selects the channel (it was silently ignored by the old `renderImage` path).
- Zero-width contrast ranges (uniform tiles) are guarded, avoiding a `renderChunks` crash on background tiles.
- Open-time validation: axes must be a subset of t/c/z/y/x with y before x; the omero channel count must match the array; composite requires at least one active channel.
- Tile hash keys include `dataType`, `zip`, `c`, `z`, `t`, `autoBoost`; `equals` compares the same options.
- Removed `DUMMY_XHR` (jobs finish/fail with a `null` request), the `OMEZarrTileSourceClass` type export and the `OpenSeadragon` module augmentation (`enable()` uses `Object.assign`), all `console` logging, and redundant base-class fields/assignments (`aspectRatio`, `dimensions`, `maxLevel`, `ready` are derived by OpenSeadragon's `ready` handler from `width`/`height`).

## Docs, demo, release
- README: prerequisites, option comments, and a "Data pipeline" section. Demo page renders the IDR label image as a composite (no `c`).
- CHANGELOG `[0.3.0] - 2026-09-11`; `package.json` version `0.3.0`. Publishing is triggered by pushing the `v0.3.0` tag after merge.

## Verification
- `tsc`, ESLint, Prettier, Vitest, and both Vite builds pass; `pnpm pack` contains dist, types, README, license.
- Node smoke tests (jsdom + napi canvas; no browser available here) against an IDR OME-Zarr 0.5 image and synthetic local images: pixel-identical output to the previous pipeline for single channels, correct composite output, edge tile sizes, abort path without unhandled rejections, and all new open-time errors.