### PR TITLE
Async-ready API, shared NgffImage, read-only metadata (v0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Optional `image` argument of the constructor and `OMEZarrTileSource.open` to reuse a loaded `NgffImage` (and its opened arrays) across tile sources for the same URL, e.g. one tile source per channel
 - `whenReady()` method returning a promise that resolves with the tile source once the OME-Zarr metadata has been loaded (and rejects on failure), and static `OMEZarrTileSource.open` shortcut that constructs a tile source and awaits it
 - `image` (ome-zarr.js `NgffImage`) and `arrays` (zarrita arrays, one per resolution level) getters for accessing OME-Zarr metadata, e.g. before adding the tile source to a viewer
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `whenReady()` method returning a promise that resolves with the tile source once the OME-Zarr metadata has been loaded (and rejects on failure), and static `OMEZarrTileSource.open` shortcut that constructs a tile source and awaits it
+- `image` (ome-zarr.js `NgffImage`) and `arrays` (zarrita arrays, one per resolution level) getters for accessing OME-Zarr metadata, e.g. before adding the tile source to a viewer
+
 ### Changed
+
+### Fixed
+
+- Errors thrown while rendering a tile (e.g. failing to get a 2D canvas context) now fail the tile download instead of leaving the tile pending with an unhandled promise rejection
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Channels without `window.start`/`window.end` in the omero metadata are now rendered using the data type range (integer types) or `[0, 1]` (floating point types) instead of the per-tile minimum/maximum
+- The OME-Zarr metadata (`image`) is treated as read-only: the `z` and `t` options are applied when requesting tiles instead of modifying the omero `rdefs`
+- The `c`, `z` and `t` options are validated against the image shape when loading the image; invalid indices fail with `open-failed` instead of failing individual tiles
+
 ### Fixed
 
 - Errors thrown while rendering a tile (e.g. failing to get a 2D canvas context) now fail the tile download instead of leaving the tile pending with an unhandled promise rejection
+- Images whose omero metadata lacks `rdefs` can now be rendered (the middle z-slice/timepoint is used unless `z`/`t` are specified)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Removed
+
+## [0.4.0] - 2026-09-12
+
+### Added
+
 - Optional `image` argument of the constructor and `OMEZarrTileSource.open` to reuse a loaded `NgffImage` (and its opened arrays) across tile sources for the same URL, e.g. one tile source per channel
 - `whenReady()` method returning a promise that resolves with the tile source once the OME-Zarr metadata has been loaded (and rejects on failure), and static `OMEZarrTileSource.open` shortcut that constructs a tile source and awaits it
 - `image` (ome-zarr.js `NgffImage`) and `arrays` (zarrita arrays, one per resolution level) getters for accessing OME-Zarr metadata, e.g. before adding the tile source to a viewer
@@ -23,8 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Errors thrown while rendering a tile (e.g. failing to get a 2D canvas context) now fail the tile download instead of leaving the tile pending with an unhandled promise rejection
 - Images whose omero metadata lacks `rdefs` can now be rendered (the middle z-slice/timepoint is used unless `z`/`t` are specified)
-
-### Removed
 
 ## [0.3.0] - 2026-09-11
 
@@ -105,7 +113,8 @@ Complete package.json
 
 Initial release
 
-[unreleased]: https://github.com/TissUUmaps/OMEZarrTileSource/compare/v0.3.0...HEAD
+[unreleased]: https://github.com/TissUUmaps/OMEZarrTileSource/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/TissUUmaps/OMEZarrTileSource/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/TissUUmaps/OMEZarrTileSource/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/TissUUmaps/OMEZarrTileSource/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/TissUUmaps/OMEZarrTileSource/compare/v0.1.1...v0.1.2

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ const tileSource2 = {
     url: url,
     // zip: undefined,  // undefined = OME-Zarr ZIP auto-detection based on .ozx suffix
     // c: undefined,  // undefined = composite of all active channels (requires dataType "context2d")
-    // z: undefined,  // undefined = omero metadata default
-    // t: undefined,  // undefined = omero metadata default
+    // z: undefined,  // undefined = omero rdefs default (middle z-slice if missing)
+    // t: undefined,  // undefined = omero rdefs default (middle timepoint if missing)
     // dataType: undefined,  // "context2d" (default, rendered tiles) or "ome-zarr" (raw single-channel chunks)
     // autoBoost: undefined  // boost brightness of dark tiles (default false)
 };
@@ -54,8 +54,8 @@ const tileSource4 = new OMEZarrTileSource({
     url: url,
     // zip: undefined,  // undefined = OME-Zarr ZIP auto-detection based on .ozx suffix
     // c: undefined,  // undefined = composite of all active channels (requires dataType "context2d")
-    // z: undefined,  // undefined = omero metadata default
-    // t: undefined,  // undefined = omero metadata default
+    // z: undefined,  // undefined = omero rdefs default (middle z-slice if missing)
+    // t: undefined,  // undefined = omero rdefs default (middle timepoint if missing)
     // dataType: undefined,  // "context2d" (default, rendered tiles) or "ome-zarr" (raw single-channel chunks)
     // autoBoost: undefined  // boost brightness of dark tiles (default false)
 });
@@ -102,6 +102,11 @@ passed to OpenSeadragon as 2D canvas contexts, using the rendering settings
 (color, color LUT/map, contrast limits, inversion) from the omero metadata. For
 multi-channel images without `c`, all active channels are rendered into a
 composite image.
+
+Contrast limits are taken from the omero channel windows (`window.start`,
+`window.end`). Channels without them are rendered using the data type range
+for integer types (e.g. `[0, 65535]` for `uint16`) and `[0, 1]` for floating
+point types.
 
 With `dataType: "ome-zarr"`, tiles are instead downloaded as raw single-channel
 zarrita chunks and passed to OpenSeadragon with the data type `ome-zarr` (see

--- a/README.md
+++ b/README.md
@@ -95,6 +95,24 @@ necessary), whereas a URL or an inline configuration object makes OpenSeadragon
 create (and load) a new instance. `whenReady()` rejects (and `image`/`arrays`
 throw) if loading fails.
 
+### Sharing OME-Zarr metadata between tile sources
+
+A loaded `NgffImage` can be reused by other directly instantiated tile sources
+for the same URL (e.g. one tile source per channel) by passing it as the second
+constructor argument (also supported by `OMEZarrTileSource.open`). This skips
+loading the OME-Zarr metadata (the `zip` option is ignored) and reuses the
+opened zarrita arrays, which ome-zarr.js caches on the `NgffImage` instance.
+The tile source never modifies the `NgffImage`, so sharing is safe:
+
+```javascript
+const tileSource1 = await OMEZarrTileSource.open({ url: url, c: 0 });
+const tileSource2 = new OMEZarrTileSource(
+  { url: url, c: 1 },
+  tileSource1.image,
+);
+// or, without a first tile source: NgffImage.load(url) from ome-zarr.js
+```
+
 ## Data pipeline
 
 By default (`dataType: "context2d"`), tiles are rendered by the tile source and

--- a/README.md
+++ b/README.md
@@ -71,6 +71,30 @@ const viewer = OpenSeadragon(
 );
 ```
 
+### Accessing OME-Zarr metadata
+
+Directly instantiated tile sources start loading the OME-Zarr metadata
+immediately. Await `whenReady()` (or use the `OMEZarrTileSource.open` shortcut)
+to access the `NgffImage` instance (ome-zarr.js) and the opened zarrita arrays
+(one per resolution level) before adding the tile source to a viewer:
+
+```javascript
+const tileSource = await OMEZarrTileSource.open({ url: url, c: 0 });
+// equivalent: await new OMEZarrTileSource({ url: url, c: 0 }).whenReady();
+
+console.log(tileSource.image.getAxesNames()); // e.g. ["t", "z", "c", "y", "x"]
+console.log(tileSource.image.omero?.channels); // omero channel metadata
+console.log(tileSource.arrays[0].shape); // full-resolution array shape
+
+viewer.addTiledImage({ tileSource: tileSource }); // no second metadata request
+```
+
+The metadata is loaded once per tile source instance: OpenSeadragon reuses a
+tile source instance passed to it as-is (waiting for it to become ready if
+necessary), whereas a URL or an inline configuration object makes OpenSeadragon
+create (and load) a new instance. `whenReady()` rejects (and `image`/`arrays`
+throw) if loading fails.
+
 ## Data pipeline
 
 By default (`dataType: "context2d"`), tiles are rendered by the tile source and

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omezarr-tilesource",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "An OpenSeadragon tile source for the OME-Zarr bioimage file format",
   "homepage": "https://github.com/TissUUmaps/OMEZarrTileSource#readme",
   "bugs": "https://github.com/TissUUmaps/OMEZarrTileSource/issues",

--- a/src/OMEZarrTileSource.ts
+++ b/src/OMEZarrTileSource.ts
@@ -11,7 +11,7 @@ import * as zarr from "zarrita";
 
 export interface OMEZarrTileSourceOptions {
   type?: "ome-zarr";
-  url: string; // TileSource.url
+  url: string;
   zip?: boolean;
   c?: number;
   z?: number;
@@ -50,21 +50,23 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
 
   static open(
     config: string | OMEZarrTileSourceOptions,
+    image?: NgffImage,
   ): Promise<OMEZarrTileSource> {
     return new OMEZarrTileSource(
       config as OMEZarrTileSourceOptions,
+      image,
     ).whenReady();
   }
 
-  constructor(url: string);
-  constructor(options: OMEZarrTileSourceOptions);
-  constructor(config: string | OMEZarrTileSourceOptions) {
+  constructor(url: string, image?: NgffImage);
+  constructor(options: OMEZarrTileSourceOptions, image?: NgffImage);
+  constructor(config: string | OMEZarrTileSourceOptions, image?: NgffImage) {
     if (typeof config === "string") {
-      super(config); // invokes getImageInfo
+      super(config); // schedules getImageInfo (async, after this constructor)
       this.url = config;
       this.dataType = "context2d";
     } else {
-      super(config.url); // invokes getImageInfo
+      super(config.url); // schedules getImageInfo (async, after this constructor)
       this.url = config.url;
       this.zip = config.zip;
       this.c = config.c;
@@ -73,6 +75,7 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
       this.dataType = config.dataType ?? "context2d";
       this.autoBoost = config.autoBoost;
     }
+    this._image = image;
     this._readyPromise.catch(() => {}); // avoid unhandled rejections
   }
 
@@ -138,10 +141,13 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
   }
 
   getImageInfo(url: string): void {
-    NgffImage.load(
-      this.zip || (this.zip === undefined && url.endsWith(".ozx"))
-        ? ZipFileStore.fromUrl(url)
-        : url,
+    Promise.resolve(
+      this._image ??
+        NgffImage.load(
+          this.zip || (this.zip === undefined && url.endsWith(".ozx"))
+            ? ZipFileStore.fromUrl(url)
+            : url,
+        ),
     )
       .then(async (image) => {
         const axisNames = image.getAxesNames();

--- a/src/OMEZarrTileSource.ts
+++ b/src/OMEZarrTileSource.ts
@@ -3,7 +3,6 @@ import {
   type Channel,
   NgffImage,
   type Omero,
-  getMinMaxValues,
   getSlices,
   renderChunks,
 } from "ome-zarr.js";
@@ -158,30 +157,47 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
           throw new Error("X axis must come after Y axis");
         }
         const arrays = await Promise.all(
-          image.paths.map((path) => image.openArray(path)),
+          image.paths.map(
+            (path) =>
+              image.openArray(path) as Promise<
+                zarr.Array<zarr.NumberDataType | zarr.BigintDataType>
+              >,
+          ),
         );
-        const channelAxis = axisNames.indexOf("c");
-        const numChannels =
-          channelAxis >= 0 ? arrays[0]!.shape[channelAxis]! : 1;
-        if (this.z !== undefined) {
-          image.setZIndex(this.z);
+        const tAxis = axisNames.indexOf("t");
+        const sizeT = tAxis >= 0 ? arrays[0]!.shape[tAxis]! : 1;
+        if (this.t !== undefined && (this.t < 0 || this.t >= sizeT)) {
+          throw new Error(
+            `Invalid t index ${this.t} for image with ${sizeT} timepoints`,
+          );
         }
-        if (this.t !== undefined) {
-          image.setTIndex(this.t);
+        const zAxis = axisNames.indexOf("z");
+        const sizeZ = zAxis >= 0 ? arrays[0]!.shape[zAxis]! : 1;
+        if (this.z !== undefined && (this.z < 0 || this.z >= sizeZ)) {
+          throw new Error(
+            `Invalid z index ${this.z} for image with ${sizeZ} z-slices`,
+          );
+        }
+        const cAxis = axisNames.indexOf("c");
+        const sizeC = cAxis >= 0 ? arrays[0]!.shape[cAxis]! : 1;
+        if (this.c !== undefined && (this.c < 0 || this.c >= sizeC)) {
+          throw new Error(
+            `Invalid c index ${this.c} for image with ${sizeC} channels`,
+          );
         }
         if (
           this.dataType !== "context2d" &&
           this.c === undefined &&
-          numChannels > 1
+          sizeC > 1
         ) {
           throw new Error(
-            `Multi-channel image with ${numChannels} channels; specify c or render as "context2d"`,
+            `Multi-channel image with ${sizeC} channels; specify c or render as "context2d"`,
           );
         }
         const omero = image.checkChannelIndex(this.c ?? 0);
-        if (omero.channels.length !== numChannels) {
+        if (omero.channels.length !== sizeC) {
           throw new Error(
-            `OME-Zarr metadata lists ${omero.channels.length} channels, but the image has ${numChannels}`,
+            `OME-Zarr metadata lists ${omero.channels.length} channels, but the image has ${sizeC}`,
           );
         }
         if (this._getActiveChannelIndices(omero).length === 0) {
@@ -300,8 +316,8 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
         {
           x: [x * tileWidth, (x + 1) * tileWidth], // clamped by zarrita
           y: [y * tileHeight, (y + 1) * tileHeight], // clamped by zarrita
-          z: omero.rdefs.defaultZ,
-          t: omero.rdefs.defaultT,
+          z: this.z ?? omero.rdefs?.defaultZ, // undefined = middle plane
+          t: this.t ?? omero.rdefs?.defaultT, // undefined = middle plane
         },
       ) as (number | zarr.Slice | null)[][];
       Promise.all(
@@ -407,7 +423,7 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
         const [vmin, vmax] =
           channel.window.start !== undefined && channel.window.end !== undefined
             ? [channel.window.start, channel.window.end]
-            : getMinMaxValues(chunks[i]);
+            : OMEZarrTileSource._getDataTypeRange(chunks[i]!);
         return vmin < vmax ? [vmin, vmax] : [vmin, vmin + 1];
       },
     );
@@ -431,5 +447,36 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
     const data = new ImageData(rgba, width, height);
     ctx.putImageData(data, 0, 0);
     return ctx;
+  }
+
+  private static _getDataTypeRange(
+    chunk: zarr.Chunk<zarr.NumberDataType | zarr.BigintDataType>,
+  ): [number, number] {
+    const { data } = chunk;
+    if (data instanceof Int8Array) {
+      return [-128, 127];
+    }
+    if (data instanceof Uint8Array) {
+      return [0, 255];
+    }
+    if (data instanceof Int16Array) {
+      return [-32768, 32767];
+    }
+    if (data instanceof Uint16Array) {
+      return [0, 65535];
+    }
+    if (data instanceof Int32Array) {
+      return [-2147483648, 2147483647];
+    }
+    if (data instanceof Uint32Array) {
+      return [0, 4294967295];
+    }
+    if (data instanceof BigInt64Array) {
+      return [-(2 ** 63), 2 ** 63 - 1]; // not exactly representable as number
+    }
+    if (data instanceof BigUint64Array) {
+      return [0, 2 ** 64 - 1]; // not exactly representable as number
+    }
+    return [0, 1]; // floating point (and bool)
   }
 }

--- a/src/OMEZarrTileSource.ts
+++ b/src/OMEZarrTileSource.ts
@@ -40,9 +40,21 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
   height: number = 10;
   private _image?: NgffImage;
   private _arrays?: zarr.Array<zarr.NumberDataType | zarr.BigintDataType>[];
+  private readonly _readyPromise = new Promise<this>((resolve, reject) => {
+    this.addOnceHandler("ready", () => resolve(this));
+    this.addOnceHandler("open-failed", (e) => reject(new Error(e.message)));
+  });
 
   static {
     OMEZarrTileSource._learnConverters(OpenSeadragon);
+  }
+
+  static open(
+    config: string | OMEZarrTileSourceOptions,
+  ): Promise<OMEZarrTileSource> {
+    return new OMEZarrTileSource(
+      config as OMEZarrTileSourceOptions,
+    ).whenReady();
   }
 
   constructor(url: string);
@@ -62,6 +74,25 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
       this.dataType = config.dataType ?? "context2d";
       this.autoBoost = config.autoBoost;
     }
+    this._readyPromise.catch(() => {}); // avoid unhandled rejections
+  }
+
+  get image(): NgffImage {
+    if (this._image === undefined) {
+      throw new Error("tile source not ready");
+    }
+    return this._image;
+  }
+
+  get arrays(): zarr.Array<zarr.NumberDataType | zarr.BigintDataType>[] {
+    if (this._arrays === undefined) {
+      throw new Error("tile source not ready");
+    }
+    return this._arrays;
+  }
+
+  whenReady(): Promise<this> {
+    return this._readyPromise;
   }
 
   supports(data: string | object | object[] | Document): boolean {
@@ -277,8 +308,8 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
         selections.map((selection) =>
           zarr.get(array, selection, { signal: abortController.signal }),
         ),
-      ).then(
-        (chunks) => {
+      )
+        .then((chunks) => {
           // no abort check needed: finish() is a no-op after abort()
           if (this.dataType === "context2d") {
             const ctx = OMEZarrTileSource._render(
@@ -295,18 +326,17 @@ export class OMEZarrTileSource extends OpenSeadragon.TileSource {
             };
             context.finish(data, null, "ome-zarr");
           }
-        },
-        (error) => {
+        })
+        .catch((error) => {
           const aborted = abortController.signal.aborted;
           abortController.abort(); // cancel the remaining channel requests
           if (!aborted) {
             context.fail(
-              `failed to render tile for level=${level}, x=${x}, y=${y}: ${error}`,
+              `failed to render tile for level=${level}, x=${x}, y=${y}: ${String(error)}`,
               null,
             );
           }
-        },
-      );
+        });
     } catch (error) {
       context.fail(
         `failed to download tile for level=${level}, x=${x}, y=${y}: ${String(error)}`,

--- a/src/OMEZarrTileSource.ts
+++ b/src/OMEZarrTileSource.ts
@@ -1,4 +1,4 @@
-import { ZipFileStore } from "@zarrita/storage";
+import ZipFileStore from "@zarrita/storage/zip";
 import {
   type Channel,
   NgffImage,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,15 +11,19 @@ export default defineConfig(({ mode }) => {
           name: "OMEZarrTileSource",
           fileName: "omezarr-tilesource",
         },
-        rollupOptions: {
+        rolldownOptions: {
           external: ["openseadragon"],
           output: {
             globals: {
               openseadragon: "OpenSeadragon",
             },
           },
+          checks: {
+            pluginTimings: false,
+          },
         },
         chunkSizeWarningLimit: 2048,
+        copyPublicDir: false,
       },
       plugins: [nodePolyfills(), dts({ bundleTypes: true })],
     };


### PR DESCRIPTION
## Summary

Extends the public API so that OME-Zarr metadata can be accessed and shared before a tile source is added to a viewer, and makes tile rendering independent of mutable omero metadata. Released as v0.4.0.

### Added
- `whenReady()` returns a promise that resolves with the tile source on the `ready` event and rejects (as an `Error`) on `open-failed`. The promise is created eagerly in the constructor so no event is missed, and a no-op `catch` avoids unhandled rejections when nobody awaits it.
- Static `OMEZarrTileSource.open(config, image?)` constructs and awaits a tile source.
- `image` (`NgffImage`) and `arrays` (one zarrita array per resolution level) getters; both throw `"tile source not ready"` before metadata is loaded.
- Optional second constructor/`open` argument to pass an already loaded `NgffImage`. `getImageInfo` then skips `NgffImage.load` (the `zip` option is ignored) and reuses the arrays cached on the image, so one tile source per channel only loads metadata once.

### Changed
- `z`/`t` are no longer written into `omero.rdefs` via `setZIndex`/`setTIndex`. They are applied per tile in `getSlices`, falling back to `rdefs?.defaultZ/defaultT` and otherwise the middle plane. The `NgffImage` is never mutated, which is what makes sharing it safe.
- `c`, `z`, `t` are bounds-checked against the full-resolution array shape during `getImageInfo`, so invalid indices surface as `open-failed` instead of per-tile failures.
- Channels without `window.start`/`window.end` use the data type range (integer types) or `[0, 1]` (float/bool) as contrast limits, replacing `getMinMaxValues` per tile. Tiles of the same channel now render consistently across the image.

### Fixed
- Synchronous errors in the tile render path (e.g. no 2D context) are now caught via `.then().catch()` and fail the tile instead of leaving it pending.
- Images without `omero.rdefs` no longer crash.

### Build
- `ZipFileStore` is imported from `@zarrita/storage/zip` (subpath) instead of the package root.
- Vite config switched from `rollupOptions` to `rolldownOptions`, disabled the `pluginTimings` check, and set `copyPublicDir: false`.

README documents the new API and contrast behaviour; CHANGELOG has the 0.4.0 entry.

## Test plan
- [x] `npm run build` succeeds and the bundle exports the new API
- [x] `await OMEZarrTileSource.open(url)` resolves; `image`/`arrays` are populated; adding the instance to a viewer issues no second metadata request
- [x] Invalid `c`/`z`/`t` reject `whenReady()` and emit `open-failed`
- [x] Two tile sources sharing one `NgffImage` (different `c`) render correctly and `image.omero.rdefs` is unchanged after viewing
- [x] Channels without omero windows render with data-type-range contrast (no per-tile flicker)