### PR TITLE
Pure ES module library with external runtime dependencies (release v0.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The package is now a pure ES module library: the `main` field and the `require` export condition have been dropped along with the UMD build
+
 ### Fixed
 
+- The runtime dependencies `zarrita`, `@zarrita/storage` and `ome-zarr.js` are no longer bundled into the library build but imported from the consuming app's installation, so that a single copy is shared (required for passing `NgffImage` instances created by the app, and reduces the bundle from ~1.5 MB to ~9 kB)
+
 ### Removed
+
+- UMD build (`dist/omezarr-tilesource.umd.cjs`)
 
 ## [0.4.0] - 2026-09-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The package is now a pure ES module library: the `main` field and the `require` export condition have been dropped along with the UMD build
+- `zarrita`, `@zarrita/storage` and `ome-zarr.js` are now peer dependencies (with version ranges) instead of regular dependencies, so that the app and the tile source resolve a single module instance
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+### Fixed
+
+### Removed
+
+## [0.5.0] - 2026-09-12
+
+### Changed
+
 - The package is now a pure ES module library: the `main` field and the `require` export condition have been dropped along with the UMD build
 
 ### Fixed
@@ -119,7 +127,8 @@ Complete package.json
 
 Initial release
 
-[unreleased]: https://github.com/TissUUmaps/OMEZarrTileSource/compare/v0.4.0...HEAD
+[unreleased]: https://github.com/TissUUmaps/OMEZarrTileSource/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/TissUUmaps/OMEZarrTileSource/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/TissUUmaps/OMEZarrTileSource/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/TissUUmaps/OMEZarrTileSource/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/TissUUmaps/OMEZarrTileSource/compare/v0.1.2...v0.2.0

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ const tileSource4 = new OMEZarrTileSource({
     // autoBoost: undefined  // boost brightness of dark tiles (default false)
 });
 
-const viewer = OpenSeadragon(
+const viewer = OpenSeadragon({
     ...
     tileSources: [
         tileSource1,
@@ -75,7 +75,7 @@ const viewer = OpenSeadragon(
         tileSource3,
         tileSource4
     ]
-);
+});
 ```
 
 ### Accessing OME-Zarr metadata

--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ Using pnpm:
 pnpm add omezarr-tilesource
 ```
 
+The package is distributed as an ES module for use with a bundler (e.g. Vite).
+Its runtime dependencies ([zarrita](https://github.com/manzt/zarrita.js),
+[@zarrita/storage](https://github.com/manzt/zarrita.js) and
+[ome-zarr.js](https://github.com/BioNGFF/ome-zarr.js)) are installed alongside
+it and are not bundled, so the app can import them (e.g. `NgffImage` from
+ome-zarr.js) and share a single copy with the tile source.
+
 ## Usage
 
 ```javascript
@@ -105,12 +112,18 @@ opened zarrita arrays, which ome-zarr.js caches on the `NgffImage` instance.
 The tile source never modifies the `NgffImage`, so sharing is safe:
 
 ```javascript
+import { NgffImage } from "ome-zarr.js";
+
+// reuse the image loaded by a first tile source
 const tileSource1 = await OMEZarrTileSource.open({ url: url, c: 0 });
 const tileSource2 = new OMEZarrTileSource(
   { url: url, c: 1 },
   tileSource1.image,
 );
-// or, without a first tile source: NgffImage.load(url) from ome-zarr.js
+
+// or load the image with the app's own ome-zarr.js import
+const image = await NgffImage.load(url);
+const tileSource3 = new OMEZarrTileSource({ url: url, c: 2 }, image);
 ```
 
 ## Data pipeline

--- a/README.md
+++ b/README.md
@@ -23,11 +23,12 @@ pnpm add omezarr-tilesource
 ```
 
 The package is distributed as an ES module for use with a bundler (e.g. Vite).
-Its runtime dependencies ([zarrita](https://github.com/manzt/zarrita.js),
+[zarrita](https://github.com/manzt/zarrita.js),
 [@zarrita/storage](https://github.com/manzt/zarrita.js) and
-[ome-zarr.js](https://github.com/BioNGFF/ome-zarr.js)) are installed alongside
-it and are not bundled, so the app can import them (e.g. `NgffImage` from
-ome-zarr.js) and share a single copy with the tile source.
+[ome-zarr.js](https://github.com/BioNGFF/ome-zarr.js) are peer dependencies
+(installed automatically by pnpm and npm 7 or newer) and are not bundled, so
+the app and the tile source share a single copy, e.g. for passing `NgffImage`
+instances loaded by the app.
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omezarr-tilesource",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "An OpenSeadragon tile source for the OME-Zarr bioimage file format",
   "homepage": "https://github.com/TissUUmaps/OMEZarrTileSource#readme",
   "bugs": "https://github.com/TissUUmaps/OMEZarrTileSource/issues",

--- a/package.json
+++ b/package.json
@@ -35,23 +35,23 @@
     "build:lib": "tsc && vite build --mode library",
     "preview": "vite preview"
   },
-  "dependencies": {
-    "@zarrita/storage": "0.2.0",
-    "ome-zarr.js": "0.0.20",
-    "zarrita": "0.7.5"
-  },
   "peerDependencies": {
-    "openseadragon": ">=6.0.0 <7.0.0"
+    "@zarrita/storage": "^0.2.0",
+    "ome-zarr.js": ">=0.0.20 <0.1.0",
+    "openseadragon": ">=6.0.0 <7.0.0",
+    "zarrita": "^0.7.5"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@microsoft/api-extractor": "^7.58.7",
     "@trivago/prettier-plugin-sort-imports": "^6.0.2",
     "@vitest/coverage-v8": "^4.1.7",
+    "@zarrita/storage": "0.2.0",
     "eslint": "^10.4.0",
     "eslint-config-prettier": "^10.1.8",
     "husky": "^9.1.7",
     "lint-staged": "^17.0.5",
+    "ome-zarr.js": "0.0.20",
     "openseadragon": "^6.1.1",
     "prettier": "^3.8.3",
     "typescript": "^6.0.3",
@@ -59,7 +59,8 @@
     "unplugin-dts": "1.0.1",
     "vite": "^8.0.14",
     "vite-plugin-node-polyfills": "^0.28.0",
-    "vitest": "^4.1.7"
+    "vitest": "^4.1.7",
+    "zarrita": "0.7.5"
   },
   "lint-staged": {
     "**/*.{js,ts}": "eslint --fix",

--- a/package.json
+++ b/package.json
@@ -15,13 +15,11 @@
     "dist"
   ],
   "types": "./dist/omezarr-tilesource.d.ts",
-  "main": "./dist/omezarr-tilesource.umd.cjs",
   "module": "./dist/omezarr-tilesource.js",
   "exports": {
     ".": {
       "types": "./dist/omezarr-tilesource.d.ts",
-      "import": "./dist/omezarr-tilesource.js",
-      "require": "./dist/omezarr-tilesource.umd.cjs"
+      "import": "./dist/omezarr-tilesource.js"
     }
   },
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,16 +6,6 @@ settings:
 
 importers:
   .:
-    dependencies:
-      "@zarrita/storage":
-        specifier: 0.2.0
-        version: 0.2.0
-      ome-zarr.js:
-        specifier: 0.0.20
-        version: 0.0.20
-      zarrita:
-        specifier: 0.7.5
-        version: 0.7.5
     devDependencies:
       "@eslint/js":
         specifier: ^10.0.1
@@ -29,6 +19,9 @@ importers:
       "@vitest/coverage-v8":
         specifier: ^4.1.7
         version: 4.1.7(vitest@4.1.7)
+      "@zarrita/storage":
+        specifier: 0.2.0
+        version: 0.2.0
       eslint:
         specifier: ^10.4.0
         version: 10.4.0
@@ -41,6 +34,9 @@ importers:
       lint-staged:
         specifier: ^17.0.5
         version: 17.0.5
+      ome-zarr.js:
+        specifier: 0.0.20
+        version: 0.0.20
       openseadragon:
         specifier: ^6.1.1
         version: 6.1.1
@@ -65,6 +61,9 @@ importers:
       vitest:
         specifier: ^4.1.7
         version: 4.1.7(@vitest/coverage-v8@4.1.7)(vite@8.0.14(yaml@2.9.0))
+      zarrita:
+        specifier: 0.7.5
+        version: 0.7.5
 
 packages:
   "@babel/code-frame@7.29.0":

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,28 +4,30 @@ import { nodePolyfills } from "vite-plugin-node-polyfills";
 
 export default defineConfig(({ mode }) => {
   if (mode === "library") {
+    // ES module library build: runtime dependencies (zarrita, ome-zarr.js,
+    // @zarrita/storage) are left external so that the consuming app installs
+    // and shares a single copy of them (e.g. to pass NgffImage instances).
     return {
       build: {
         lib: {
+          formats: ["es"],
           entry: "src/main.ts",
-          name: "OMEZarrTileSource",
           fileName: "omezarr-tilesource",
         },
         rolldownOptions: {
-          external: ["openseadragon"],
-          output: {
-            globals: {
-              openseadragon: "OpenSeadragon",
-            },
-          },
+          external: [
+            "@zarrita/storage/zip",
+            "ome-zarr.js",
+            "openseadragon",
+            "zarrita",
+          ],
           checks: {
             pluginTimings: false,
           },
         },
-        chunkSizeWarningLimit: 2048,
         copyPublicDir: false,
       },
-      plugins: [nodePolyfills(), dts({ bundleTypes: true })],
+      plugins: [dts({ bundleTypes: true })],
     };
   }
   return {


### PR DESCRIPTION
## Summary

The published package bundled zarrita, ome-zarr.js and @zarrita/storage into `dist/` even though they are declared as runtime dependencies. An app that also imports ome-zarr.js (e.g. to load an `NgffImage` and pass it to the tile source, as suggested in the README) therefore shipped two copies of zarrita. This PR turns the package into a pure ES module library whose runtime dependencies are resolved from the consuming app's installation.

## Changes

- **`vite.config.ts`**: the library build emits ESM only (`formats: ["es"]`) and lists `@zarrita/storage/zip`, `ome-zarr.js`, `openseadragon` and `zarrita` as externals (the exact specifiers imported by `src/OMEZarrTileSource.ts`). The UMD `name`, `output.globals`, `chunkSizeWarningLimit` and the `nodePolyfills` plugin are dropped from the library build since nothing Node-specific is bundled anymore. The demo build is unchanged.
- **`package.json`**: removed the `main` field and the `require` export condition (both pointed at the UMD file); `types`, `module` and the `import` condition remain. `zarrita` (`^0.7.5`), `@zarrita/storage` (`^0.2.0`) and `ome-zarr.js` (`>=0.0.20 <0.1.0`) moved from `dependencies` to `peerDependencies` so the app and the library resolve one module instance (a mismatching app version otherwise yields a nested copy); the exact pins stay in `devDependencies` for the demo and type builds. Version bumped to 0.5.0.
- **`README.md`**: installation section notes that the package is ESM for bundlers and that its dependencies are installed alongside and shared with the app; the sharing example now shows `NgffImage.load` via the app's own ome-zarr.js import.
- **`CHANGELOG.md`**: 0.5.0 section (Changed / Fixed / Removed) and compare links.

## Impact

- `dist/` shrinks from `omezarr-tilesource.js` (87 kB) plus ~1.5 MB of codec chunks and a 1.5 MB UMD file to a single 9 kB `omezarr-tilesource.js` and the `.d.ts`.
- Breaking for CommonJS/script-tag consumers: no UMD build and no `require` entry anymore (hence a minor bump). ESM consumers need no code changes.
